### PR TITLE
Improve Transfer Size Distribution chart readability and UX

### DIFF
--- a/src/components/chart/transfer-size-histogram.tsx
+++ b/src/components/chart/transfer-size-histogram.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Box, Button, Card, CardHeader } from '@mui/material'
+import { Box, Card, CardHeader, Stack, ToggleButton, ToggleButtonGroup } from '@mui/material'
 import { useMemo, useState } from 'react'
 import useSWR from 'swr'
 import { Chart, useChart } from 'src/components/chart'
@@ -19,6 +19,7 @@ export default function TransferSizeHistogram() {
     const network = getNetwork()
     const { timePeriod } = useGlobalContext()
     const [metric, setMetric] = useState<'count' | 'usd'>('count')
+    const [scale, setScale] = useState<'linear' | 'log'>('linear')
 
     const { data, isLoading } = useSWR<SizeHistogramRow[]>(
         `${endpoints.sizeHistogram}?network=${network}&period=${encodeURIComponent(timePeriod)}`,
@@ -26,18 +27,21 @@ export default function TransferSizeHistogram() {
         { revalidateOnFocus: false },
     )
 
-    const { series, categories } = useMemo(() => {
+    const { series, categories, rawValues } = useMemo(() => {
         const rows = data ?? []
         const byBucket = Object.fromEntries(rows.map(r => [r.bucket, r]))
         const cats = BUCKET_ORDER.filter(b => byBucket[b])
-        const values = cats.map(b =>
+        const raw = cats.map(b =>
             metric === 'count' ? Number(byBucket[b].count) || 0 : Number(byBucket[b].usd) || 0,
         )
+        const useLog = metric === 'usd' && scale === 'log'
+        const values = useLog ? raw.map(v => (v > 0 ? Math.log10(v) : 0)) : raw
         return {
             categories: cats,
+            rawValues: raw,
             series: [{ name: metric === 'count' ? 'Transfers' : 'Volume (USD)', data: values }],
         }
-    }, [data, metric])
+    }, [data, metric, scale])
 
     const options = useChart({
         chart: { type: 'bar', toolbar: { show: false }, animations: { enabled: false } },
@@ -55,8 +59,13 @@ export default function TransferSizeHistogram() {
             categories,
             labels: {
                 formatter: (v: string | number) => {
-                    const n = Number(v)
+                    let n = Number(v)
                     if (!Number.isFinite(n)) return String(v)
+                    // If log-scale is active we store log10(value) on the series,
+                    // so transform axis ticks back to real values for display.
+                    if (metric === 'usd' && scale === 'log') {
+                        n = n > 0 ? Math.pow(10, n) : 0
+                    }
                     if (metric === 'usd') {
                         if (n >= 1e9) return `$${(n / 1e9).toFixed(1)}B`
                         if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}M`
@@ -72,6 +81,8 @@ export default function TransferSizeHistogram() {
         yaxis: { labels: { style: { fontSize: '12px' } } },
         legend: { show: false },
         tooltip: {
+            theme: 'dark',
+            fillSeriesColor: false,
             y: {
                 formatter: (v: number) =>
                     metric === 'usd'
@@ -79,6 +90,48 @@ export default function TransferSizeHistogram() {
                               maximumFractionDigits: 0,
                           })}`
                         : `${Number(v).toLocaleString()}`,
+            },
+            custom: ({ seriesIndex, dataPointIndex, w }: any) => {
+                // Always display the raw (pre-log) value in the tooltip
+                const value = rawValues[dataPointIndex] ?? 0
+                const category = w.globals.labels[dataPointIndex]
+                const color = w.globals.colors[dataPointIndex] || w.globals.colors[0]
+                const formatted =
+                    metric === 'usd'
+                        ? `$${Number(value).toLocaleString(undefined, {
+                              maximumFractionDigits: 0,
+                          })}`
+                        : Number(value).toLocaleString()
+                void seriesIndex
+                const label = metric === 'usd' ? 'Volume (USD)' : 'Transfers'
+                return `
+                    <div style="
+                        background: rgba(22, 28, 36, 0.92);
+                        color: #fff;
+                        border-radius: 8px;
+                        padding: 8px 12px;
+                        box-shadow: 0 4px 12px rgba(0,0,0,0.35);
+                        font-size: 12px;
+                        min-width: 140px;
+                    ">
+                        <div style="
+                            font-weight: 600;
+                            color: rgba(255,255,255,0.75);
+                            margin-bottom: 4px;
+                        ">${category}</div>
+                        <div style="display: flex; align-items: center; gap: 8px;">
+                            <span style="
+                                width: 8px;
+                                height: 8px;
+                                border-radius: 50%;
+                                background: ${color};
+                                display: inline-block;
+                            "></span>
+                            <span style="color: rgba(255,255,255,0.75);">${label}:</span>
+                            <span style="margin-left: auto; font-weight: 600;">${formatted}</span>
+                        </div>
+                    </div>
+                `
             },
         },
     })
@@ -89,22 +142,30 @@ export default function TransferSizeHistogram() {
                 title="Transfer Size Distribution"
                 subheader="How big are typical bridge transfers?"
                 action={
-                    <Box sx={{ display: 'flex', gap: 1 }}>
-                        <Button
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
+                        {metric === 'usd' && (
+                            <ToggleButtonGroup
+                                size="small"
+                                exclusive
+                                value={scale}
+                                onChange={(_, v) => v && setScale(v)}
+                                aria-label="scale"
+                            >
+                                <ToggleButton value="linear">Linear</ToggleButton>
+                                <ToggleButton value="log">Log</ToggleButton>
+                            </ToggleButtonGroup>
+                        )}
+                        <ToggleButtonGroup
                             size="small"
-                            variant={metric === 'count' ? 'contained' : 'outlined'}
-                            onClick={() => setMetric('count')}
+                            exclusive
+                            value={metric}
+                            onChange={(_, v) => v && setMetric(v)}
+                            aria-label="metric"
                         >
-                            Count
-                        </Button>
-                        <Button
-                            size="small"
-                            variant={metric === 'usd' ? 'contained' : 'outlined'}
-                            onClick={() => setMetric('usd')}
-                        >
-                            USD
-                        </Button>
-                    </Box>
+                            <ToggleButton value="usd">USD</ToggleButton>
+                            <ToggleButton value="count">Count</ToggleButton>
+                        </ToggleButtonGroup>
+                    </Stack>
                 }
             />
             <Box sx={{ p: 2, pt: 0 }}>


### PR DESCRIPTION
## Summary

Three small fixes to the **Transfer Size Distribution** chart on `/flows`:

- **Readable tooltip** — hover background was white against white text, making values invisible. Replaced with a dark custom tooltip (colored dot + bucket label + formatted value).
- **Consistent toggle style** — swapped the old `Count` / `USD` `Button`s for a `ToggleButtonGroup` matching the Sankey chart header above it (same order: USD first, Count second).
- **Linear / Log scale toggle (USD mode only)** — bridge volume is genuinely dominated by $100k+ transfers (~88% of total USD), so on a linear scale the `<$10k` buckets were essentially invisible (~37,000x spread between smallest and largest bars). Added a `Linear`/`Log` toggle that only appears in USD mode so users can flip to log scale when they want to see all buckets clearly. Tooltip always shows the real dollar amount, and x-axis ticks are transformed back to real values (`$10, $100, $1k, $10k, $100k, $1M…`).

## Changes

- `src/components/chart/transfer-size-histogram.tsx`

## Notes

- The log transform is done on the series data (`log10(value)`) rather than via Apex's `xaxis.logarithmic` flag, because Apex's horizontal-bar renderer ignores the log flag for bar widths (only tick labels respect it).
- Count mode keeps a single toggle group — all count values are within the same order of magnitude, so log scaling isn't needed there.