### PR TITLE
Token drilldown: listing + per-token analytics pages

### DIFF
--- a/src/app/(dashboard)/tokens/[id]/page.tsx
+++ b/src/app/(dashboard)/tokens/[id]/page.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { Box, Card, Stack, Typography } from '@mui/material'
+import useSWR from 'swr'
+import { PageTitle } from 'src/components/page-title'
+import {
+    TokenOverview,
+    TokenVolumeChart,
+    TokenTopHolders,
+    TokenSizeHistogram,
+} from 'src/components/token'
+import { DashboardContent } from 'src/layouts/dashboard'
+import { getNetwork } from 'src/hooks/get-network-storage'
+import { useGlobalContext } from 'src/provider/global-provider'
+import { NotFoundView } from 'src/sections/error'
+import { endpoints, fetcher } from 'src/utils/axios'
+import { getTokenMeta } from 'src/utils/token-meta'
+import type { TokenOverviewResponse } from 'src/pages/api/token/[id]/overview'
+
+interface PageProps {
+    params: { id: string }
+}
+
+export default function TokenDetailPage({ params: { id } }: PageProps) {
+    const network = getNetwork()
+    const { timePeriod } = useGlobalContext()
+
+    const numericId = Number(id)
+    const meta = getTokenMeta(network, numericId)
+
+    const url = Number.isFinite(numericId)
+        ? `${endpoints.token.overview(numericId)}?network=${network}&period=${encodeURIComponent(
+              timePeriod,
+          )}`
+        : null
+
+    const { data, isLoading } = useSWR<TokenOverviewResponse>(url, fetcher, {
+        revalidateOnFocus: false,
+    })
+
+    if (!Number.isFinite(numericId) || !meta) {
+        return <NotFoundView />
+    }
+
+    return (
+        <DashboardContent maxWidth="xl">
+            <PageTitle title={`${meta.ticker} · Token`} />
+
+            {/* Header */}
+            <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 3 }}>
+                <Box
+                    sx={{
+                        width: 56,
+                        height: 56,
+                        borderRadius: 2,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        bgcolor: meta.color,
+                        color: '#fff',
+                        fontWeight: 700,
+                        fontSize: 20,
+                        overflow: 'hidden',
+                    }}
+                >
+                    {meta.icon ? (
+                        /* eslint-disable-next-line @next/next/no-img-element */
+                        <img
+                            src={meta.icon}
+                            alt={meta.ticker}
+                            width={36}
+                            height={36}
+                            style={{ objectFit: 'contain' }}
+                        />
+                    ) : (
+                        meta.ticker.slice(0, 2).toUpperCase()
+                    )}
+                </Box>
+                <Box>
+                    <Typography variant="h4" sx={{ lineHeight: 1.1 }}>
+                        {meta.ticker}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                        {meta.name} · Token #{meta.id} · {meta.decimals.toFixed(0)} decimals
+                    </Typography>
+                </Box>
+            </Stack>
+
+            {/* Stat tiles */}
+            <TokenOverview data={data} isLoading={isLoading} />
+
+            {/* Inflow / outflow chart */}
+            <TokenVolumeChart tokenId={numericId} tokenColor={meta.color} />
+
+            {/* Holders & size distribution side-by-side on desktop */}
+            <TokenTopHolders tokenId={numericId} />
+            <TokenSizeHistogram tokenId={numericId} tokenColor={meta.color} />
+
+            {!isLoading && data && data.totals.total_tx_count === 0 && (
+                <Card sx={{ mt: 3, p: 4, textAlign: 'center' }}>
+                    <Typography variant="body2" color="text.secondary">
+                        No bridge activity for {meta.ticker} in the selected period.
+                    </Typography>
+                </Card>
+            )}
+        </DashboardContent>
+    )
+}

--- a/src/app/(dashboard)/tokens/page.tsx
+++ b/src/app/(dashboard)/tokens/page.tsx
@@ -1,0 +1,274 @@
+'use client'
+
+import {
+    Box,
+    Card,
+    CardActionArea,
+    CardContent,
+    Grid,
+    Skeleton,
+    Stack,
+    Tooltip,
+    Typography,
+} from '@mui/material'
+import Link from 'next/link'
+import { useMemo } from 'react'
+import useSWR from 'swr'
+import { Iconify } from 'src/components/iconify'
+import { PageTitle } from 'src/components/page-title'
+import { DashboardContent } from 'src/layouts/dashboard'
+import { getNetwork } from 'src/hooks/get-network-storage'
+import { useGlobalContext } from 'src/provider/global-provider'
+import { paths } from 'src/routes/paths'
+import { endpoints, fetcher } from 'src/utils/axios'
+import { fNumber } from 'src/utils/format-number'
+import { getTokenMetaList, TokenMeta } from 'src/utils/token-meta'
+import type { TokenSummaryResponse, TokenSummaryRow } from 'src/pages/api/token/summary'
+
+function formatUsd(value: number): string {
+    if (!Number.isFinite(value)) return '$0'
+    const abs = Math.abs(value)
+    const sign = value < 0 ? '-' : ''
+    if (abs >= 1e9) return `${sign}$${(abs / 1e9).toFixed(2)}B`
+    if (abs >= 1e6) return `${sign}$${(abs / 1e6).toFixed(2)}M`
+    if (abs >= 1e3) return `${sign}$${(abs / 1e3).toFixed(1)}k`
+    return `${sign}$${abs.toFixed(0)}`
+}
+
+type EnrichedRow = TokenSummaryRow & {
+    meta: TokenMeta
+    net_usd: number
+}
+
+export default function TokensIndexPage() {
+    const network = getNetwork()
+    const { timePeriod } = useGlobalContext()
+
+    // Memoize tokens by network so it doesn't generate a new array reference each render
+    const tokens = useMemo(() => getTokenMetaList(network), [network])
+
+    const url = `${endpoints.token.summary}?network=${network}&period=${encodeURIComponent(
+        timePeriod,
+    )}`
+    const { data, isLoading, error } = useSWR<TokenSummaryResponse>(url, fetcher, {
+        revalidateOnFocus: false,
+        // Avoid endless retries if the backend hangs / errors
+        shouldRetryOnError: false,
+        keepPreviousData: false,
+    })
+
+    const rows: EnrichedRow[] = useMemo(() => {
+        if (!data) return []
+
+        const apiByToken = Object.fromEntries(data.rows.map(r => [r.token_id, r]))
+
+        return tokens
+            .map(meta => {
+                const row = apiByToken[meta.id] ?? {
+                    token_id: meta.id,
+                    inflow_usd: 0,
+                    outflow_usd: 0,
+                    inflow_count: 0,
+                    outflow_count: 0,
+                    total_volume_usd: 0,
+                    total_tx_count: 0,
+                    unique_senders: 0,
+                    avg_tx_usd: 0,
+                    max_tx_usd: 0,
+                    prev_total_volume_usd: 0,
+                }
+                return {
+                    ...row,
+                    meta,
+                    net_usd: row.inflow_usd - row.outflow_usd,
+                }
+            })
+            .sort((a, b) => b.total_volume_usd - a.total_volume_usd)
+    }, [data, tokens])
+
+    const showSkeletons = !error && (isLoading || !data)
+
+    return (
+        <DashboardContent maxWidth="xl">
+            <PageTitle title="Tokens" />
+            <Box sx={{ mb: 3 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 0.5 }}>
+                    <Iconify
+                        icon="solar:wallet-bold-duotone"
+                        width={28}
+                        sx={{ color: 'primary.main' }}
+                    />
+                    <Typography variant="h4">Tokens</Typography>
+                </Box>
+                <Typography variant="body2" color="text.secondary">
+                    Click a token to drill down: inflow/outflow, top senders, and transfer-size
+                    distribution.
+                </Typography>
+            </Box>
+
+            <Grid container spacing={2}>
+                {showSkeletons &&
+                    Array.from({ length: tokens.length || 8 }).map((_, i) => (
+                        <Grid key={`s-${i}`} item xs={12} sm={6} md={3}>
+                            <Card sx={{ p: 2.5 }}>
+                                <Skeleton variant="rectangular" height={120} />
+                            </Card>
+                        </Grid>
+                    ))}
+
+                {!!error && (
+                    <Grid item xs={12}>
+                        <Card sx={{ p: 4, textAlign: 'center' }}>
+                            <Typography variant="body2" color="error.main">
+                                Failed to load tokens. Please try again.
+                            </Typography>
+                        </Card>
+                    </Grid>
+                )}
+
+                {!showSkeletons && !error && rows.length === 0 && (
+                    <Grid item xs={12}>
+                        <Card sx={{ p: 4, textAlign: 'center' }}>
+                            <Typography variant="body2" color="text.secondary">
+                                No tokens configured for this network.
+                            </Typography>
+                        </Card>
+                    </Grid>
+                )}
+
+                {!showSkeletons &&
+                    !error &&
+                    rows.map(row => (
+                        <Grid key={row.token_id} item xs={12} sm={6} md={3}>
+                            <Card sx={{ height: '100%' }}>
+                                <CardActionArea
+                                    LinkComponent={Link}
+                                    href={paths.tokens.details(row.token_id)}
+                                    sx={{ height: '100%' }}
+                                >
+                                    <CardContent sx={{ p: 2.5 }}>
+                                        {/* Header: icon + ticker + name */}
+                                        <Stack
+                                            direction="row"
+                                            spacing={2}
+                                            alignItems="center"
+                                            sx={{ mb: 2 }}
+                                        >
+                                            <Box
+                                                sx={{
+                                                    width: 48,
+                                                    height: 48,
+                                                    borderRadius: 1.5,
+                                                    display: 'flex',
+                                                    alignItems: 'center',
+                                                    justifyContent: 'center',
+                                                    bgcolor: row.meta.color,
+                                                    color: '#fff',
+                                                    fontWeight: 700,
+                                                    overflow: 'hidden',
+                                                    flexShrink: 0,
+                                                }}
+                                            >
+                                                {row.meta.icon ? (
+                                                    /* eslint-disable-next-line @next/next/no-img-element */
+                                                    <img
+                                                        src={row.meta.icon}
+                                                        alt={row.meta.ticker}
+                                                        width={32}
+                                                        height={32}
+                                                        style={{ objectFit: 'contain' }}
+                                                    />
+                                                ) : (
+                                                    row.meta.ticker.slice(0, 2).toUpperCase()
+                                                )}
+                                            </Box>
+                                            <Stack spacing={0} sx={{ minWidth: 0, flex: 1 }}>
+                                                <Typography variant="h6" sx={{ lineHeight: 1.1 }}>
+                                                    {row.meta.ticker}
+                                                </Typography>
+                                                <Typography
+                                                    variant="caption"
+                                                    color="text.secondary"
+                                                    noWrap
+                                                >
+                                                    {row.meta.name}
+                                                </Typography>
+                                            </Stack>
+                                            <Iconify
+                                                icon="eva:arrow-ios-forward-fill"
+                                                width={20}
+                                                sx={{ color: 'text.disabled', flexShrink: 0 }}
+                                            />
+                                        </Stack>
+
+                                        {/* Volume highlight */}
+                                        <Stack spacing={0.25} sx={{ mb: 2 }}>
+                                            <Typography variant="caption" color="text.secondary">
+                                                Total Volume
+                                            </Typography>
+                                            <Typography variant="h5">
+                                                {formatUsd(row.total_volume_usd)}
+                                            </Typography>
+                                        </Stack>
+
+                                        {/* Mini metrics row */}
+                                        <Stack
+                                            direction="row"
+                                            spacing={1}
+                                            sx={{ borderTop: 1, borderColor: 'divider', pt: 1.5 }}
+                                        >
+                                            <Tooltip title="Bridged into Sui (ETH → SUI)">
+                                                <Stack spacing={0.25} sx={{ flex: 1 }}>
+                                                    <Typography
+                                                        variant="caption"
+                                                        color="text.secondary"
+                                                    >
+                                                        Inflow
+                                                    </Typography>
+                                                    <Typography
+                                                        variant="body2"
+                                                        fontWeight={600}
+                                                        color="success.main"
+                                                    >
+                                                        {formatUsd(row.inflow_usd)}
+                                                    </Typography>
+                                                </Stack>
+                                            </Tooltip>
+                                            <Tooltip title="Bridged out of Sui (SUI → ETH)">
+                                                <Stack spacing={0.25} sx={{ flex: 1 }}>
+                                                    <Typography
+                                                        variant="caption"
+                                                        color="text.secondary"
+                                                    >
+                                                        Outflow
+                                                    </Typography>
+                                                    <Typography
+                                                        variant="body2"
+                                                        fontWeight={600}
+                                                        color="error.main"
+                                                    >
+                                                        {formatUsd(row.outflow_usd)}
+                                                    </Typography>
+                                                </Stack>
+                                            </Tooltip>
+                                            <Stack spacing={0.25} sx={{ flex: 1 }}>
+                                                <Typography
+                                                    variant="caption"
+                                                    color="text.secondary"
+                                                >
+                                                    Transfers
+                                                </Typography>
+                                                <Typography variant="body2" fontWeight={600}>
+                                                    {fNumber(row.total_tx_count) || '0'}
+                                                </Typography>
+                                            </Stack>
+                                        </Stack>
+                                    </CardContent>
+                                </CardActionArea>
+                            </Card>
+                        </Grid>
+                    ))}
+            </Grid>
+        </DashboardContent>
+    )
+}

--- a/src/components/token/index.ts
+++ b/src/components/token/index.ts
@@ -1,0 +1,4 @@
+export { TokenOverview } from './token-overview'
+export { TokenVolumeChart } from './token-volume-chart'
+export { TokenTopHolders } from './token-top-holders'
+export { TokenSizeHistogram } from './token-size-histogram'

--- a/src/components/token/token-overview.tsx
+++ b/src/components/token/token-overview.tsx
@@ -1,0 +1,235 @@
+'use client'
+
+import { Box, Card, Grid, Skeleton, Stack, Typography } from '@mui/material'
+import { Iconify } from 'src/components/iconify'
+import { fNumber, fShortenNumber } from 'src/utils/format-number'
+import type { TokenOverviewResponse } from 'src/pages/api/token/[id]/overview'
+
+function formatUsd(value: number): string {
+    if (!Number.isFinite(value)) return '$0'
+    const abs = Math.abs(value)
+    const sign = value < 0 ? '-' : ''
+    if (abs >= 1e9) return `${sign}$${(abs / 1e9).toFixed(2)}B`
+    if (abs >= 1e6) return `${sign}$${(abs / 1e6).toFixed(2)}M`
+    if (abs >= 1e3) return `${sign}$${(abs / 1e3).toFixed(1)}k`
+    return `${sign}$${abs.toFixed(2)}`
+}
+
+function pctChange(current: number, previous: number): number | null {
+    if (!previous || previous === 0) return null
+    return ((current - previous) / previous) * 100
+}
+
+type StatCardProps = {
+    title: string
+    value: string
+    subValue?: string
+    change?: number | null
+    color?: string
+    icon?: string
+}
+
+function StatCard({ title, value, subValue, change, color = 'primary.main', icon }: StatCardProps) {
+    const isUp = (change ?? 0) > 0
+    const isDown = (change ?? 0) < 0
+    return (
+        <Card sx={{ p: 2.5, height: '100%' }}>
+            <Stack direction="row" alignItems="flex-start" spacing={1.5}>
+                {icon && (
+                    <Box
+                        sx={{
+                            width: 40,
+                            height: 40,
+                            borderRadius: 1.5,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            bgcolor: 'background.neutral',
+                            color,
+                            flexShrink: 0,
+                        }}
+                    >
+                        <Iconify icon={icon} width={22} />
+                    </Box>
+                )}
+                <Stack spacing={0.25} sx={{ minWidth: 0, flex: 1 }}>
+                    <Typography variant="caption" color="text.secondary">
+                        {title}
+                    </Typography>
+                    <Typography variant="h5" sx={{ lineHeight: 1.2 }}>
+                        {value}
+                    </Typography>
+                    <Stack direction="row" alignItems="center" spacing={0.75}>
+                        {subValue && (
+                            <Typography variant="caption" color="text.secondary">
+                                {subValue}
+                            </Typography>
+                        )}
+                        {change !== undefined && change !== null && (
+                            <Stack
+                                direction="row"
+                                alignItems="center"
+                                spacing={0.25}
+                                sx={{
+                                    color: isUp
+                                        ? 'success.main'
+                                        : isDown
+                                          ? 'error.main'
+                                          : 'text.disabled',
+                                }}
+                            >
+                                <Iconify
+                                    icon={
+                                        isUp
+                                            ? 'eva:trending-up-fill'
+                                            : isDown
+                                              ? 'eva:trending-down-fill'
+                                              : 'eva:minus-fill'
+                                    }
+                                    width={14}
+                                />
+                                <Typography variant="caption" fontWeight={600}>
+                                    {Math.abs(change).toFixed(1)}%
+                                </Typography>
+                            </Stack>
+                        )}
+                    </Stack>
+                </Stack>
+            </Stack>
+        </Card>
+    )
+}
+
+type Props = {
+    data?: TokenOverviewResponse
+    isLoading?: boolean
+}
+
+export function TokenOverview({ data, isLoading }: Props) {
+    if (isLoading || !data) {
+        return (
+            <Grid container spacing={2}>
+                {Array.from({ length: 4 }).map((_, i) => (
+                    <Grid key={i} item xs={12} sm={6} md={3}>
+                        <Card sx={{ p: 2.5, height: '100%' }}>
+                            <Skeleton variant="text" width="60%" />
+                            <Skeleton variant="text" width="80%" height={36} />
+                            <Skeleton variant="text" width="40%" />
+                        </Card>
+                    </Grid>
+                ))}
+            </Grid>
+        )
+    }
+
+    const volumePct = pctChange(data.totals.total_volume_usd, data.previous.total_volume_usd)
+    const txPct = pctChange(data.totals.total_tx_count, data.previous.total_tx_count)
+    const userPct = pctChange(data.totals.unique_senders, data.previous.unique_senders)
+
+    const netUsd = data.direction.net_usd
+    const netLabel =
+        netUsd >= 0 ? `+${formatUsd(netUsd)} → SUI` : `${formatUsd(Math.abs(netUsd))} → ETH`
+
+    return (
+        <Grid container spacing={2}>
+            <Grid item xs={12} sm={6} md={3}>
+                <StatCard
+                    title="Total Volume"
+                    value={formatUsd(data.totals.total_volume_usd)}
+                    subValue="vs previous period"
+                    change={volumePct}
+                    icon="solar:dollar-minimalistic-bold-duotone"
+                    color="primary.main"
+                />
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+                <StatCard
+                    title="Transfers"
+                    value={fNumber(data.totals.total_tx_count) || '0'}
+                    subValue="vs previous period"
+                    change={txPct}
+                    icon="solar:transfer-horizontal-bold-duotone"
+                    color="info.main"
+                />
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+                <StatCard
+                    title="Unique Senders"
+                    value={fNumber(data.totals.unique_senders) || '0'}
+                    subValue="vs previous period"
+                    change={userPct}
+                    icon="solar:users-group-rounded-bold-duotone"
+                    color="warning.main"
+                />
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+                <StatCard
+                    title="Net Flow"
+                    value={netLabel}
+                    subValue={`Avg ${formatUsd(data.totals.avg_tx_usd)} / tx`}
+                    icon="solar:routing-2-bold-duotone"
+                    color={netUsd >= 0 ? 'success.main' : 'error.main'}
+                />
+            </Grid>
+
+            <Grid item xs={12} sm={6} md={3}>
+                <Card sx={{ p: 2.5 }}>
+                    <Stack spacing={0.5}>
+                        <Typography variant="caption" color="text.secondary">
+                            Inflow (ETH → SUI)
+                        </Typography>
+                        <Typography variant="h6" color="success.main">
+                            {formatUsd(data.direction.inflow_usd)}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                            {fNumber(data.direction.inflow_count)} transfers
+                        </Typography>
+                    </Stack>
+                </Card>
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+                <Card sx={{ p: 2.5 }}>
+                    <Stack spacing={0.5}>
+                        <Typography variant="caption" color="text.secondary">
+                            Outflow (SUI → ETH)
+                        </Typography>
+                        <Typography variant="h6" color="error.main">
+                            {formatUsd(data.direction.outflow_usd)}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                            {fNumber(data.direction.outflow_count)} transfers
+                        </Typography>
+                    </Stack>
+                </Card>
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+                <Card sx={{ p: 2.5 }}>
+                    <Stack spacing={0.5}>
+                        <Typography variant="caption" color="text.secondary">
+                            Largest Transfer
+                        </Typography>
+                        <Typography variant="h6">{formatUsd(data.totals.max_tx_usd)}</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                            Min {formatUsd(data.totals.min_tx_usd)}
+                        </Typography>
+                    </Stack>
+                </Card>
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+                <Card sx={{ p: 2.5 }}>
+                    <Stack spacing={0.5}>
+                        <Typography variant="caption" color="text.secondary">
+                            Current Price
+                        </Typography>
+                        <Typography variant="h6">
+                            ${fShortenNumber(data.price_usd) || '0'}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                            Decimals: {data.decimals}
+                        </Typography>
+                    </Stack>
+                </Card>
+            </Grid>
+        </Grid>
+    )
+}

--- a/src/components/token/token-size-histogram.tsx
+++ b/src/components/token/token-size-histogram.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { Box, Card, CardHeader, Stack, ToggleButton, ToggleButtonGroup } from '@mui/material'
+import { useMemo, useState } from 'react'
+import useSWR from 'swr'
+import { Chart, useChart } from 'src/components/chart'
+import { getNetwork } from 'src/hooks/get-network-storage'
+import { useGlobalContext } from 'src/provider/global-provider'
+import { endpoints, fetcher } from 'src/utils/axios'
+import type { TokenSizeBucket } from 'src/pages/api/token/[id]/size-histogram'
+
+const BUCKET_ORDER = ['< $100', '$100 – $1k', '$1k – $10k', '$10k – $100k', '$100k – $1M', '$1M+']
+
+type Metric = 'count' | 'usd'
+
+type Props = {
+    tokenId: number
+    tokenColor: string
+}
+
+export function TokenSizeHistogram({ tokenId, tokenColor }: Props) {
+    const network = getNetwork()
+    const { timePeriod } = useGlobalContext()
+    const [metric, setMetric] = useState<Metric>('count')
+
+    const url = `${endpoints.token.sizeHistogram(tokenId)}?network=${network}&period=${encodeURIComponent(
+        timePeriod,
+    )}`
+
+    const { data, isLoading } = useSWR<TokenSizeBucket[]>(url, fetcher, {
+        revalidateOnFocus: false,
+    })
+
+    const { series, categories } = useMemo(() => {
+        const rows = data ?? []
+        const byBucket = Object.fromEntries(rows.map(r => [r.bucket, r]))
+        const cats = BUCKET_ORDER.filter(b => byBucket[b])
+        const values = cats.map(b =>
+            metric === 'count' ? Number(byBucket[b].count) || 0 : Number(byBucket[b].usd) || 0,
+        )
+        return {
+            categories: cats,
+            series: [{ name: metric === 'count' ? 'Transfers' : 'Volume (USD)', data: values }],
+        }
+    }, [data, metric])
+
+    const options = useChart({
+        chart: { type: 'bar', toolbar: { show: false }, animations: { enabled: false } },
+        plotOptions: {
+            bar: { horizontal: true, borderRadius: 3, barHeight: '65%', distributed: true },
+        },
+        colors: [tokenColor || '#4DA2FF', '#22C55E', '#FACC15', '#F97316', '#EF4444', '#8B5CF6'],
+        dataLabels: { enabled: false },
+        xaxis: {
+            categories,
+            labels: {
+                formatter: (v: string | number) => {
+                    const n = Number(v)
+                    if (!Number.isFinite(n)) return String(v)
+                    if (metric === 'usd') {
+                        if (n >= 1e9) return `$${(n / 1e9).toFixed(1)}B`
+                        if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}M`
+                        if (n >= 1e3) return `$${(n / 1e3).toFixed(1)}k`
+                        return `$${n.toFixed(0)}`
+                    }
+                    if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M`
+                    if (n >= 1e3) return `${(n / 1e3).toFixed(1)}k`
+                    return String(n)
+                },
+            },
+        },
+        legend: { show: false },
+        tooltip: {
+            theme: 'dark',
+            y: {
+                formatter: (v: number) =>
+                    metric === 'usd'
+                        ? `$${Number(v).toLocaleString(undefined, {
+                              maximumFractionDigits: 0,
+                          })}`
+                        : `${Number(v).toLocaleString()}`,
+            },
+        },
+    })
+
+    return (
+        <Card sx={{ mt: 3 }}>
+            <CardHeader
+                title="Transfer Size Distribution"
+                subheader="How big are transfers of this token?"
+                action={
+                    <Stack direction="row" spacing={1}>
+                        <ToggleButtonGroup
+                            size="small"
+                            exclusive
+                            value={metric}
+                            onChange={(_, v) => v && setMetric(v)}
+                        >
+                            <ToggleButton value="usd">USD</ToggleButton>
+                            <ToggleButton value="count">Count</ToggleButton>
+                        </ToggleButtonGroup>
+                    </Stack>
+                }
+            />
+            <Box sx={{ p: 2, pt: 0 }}>
+                <Chart
+                    type="bar"
+                    series={series}
+                    options={options}
+                    height={320}
+                    forceLoading={isLoading && !data?.length}
+                />
+            </Box>
+        </Card>
+    )
+}

--- a/src/components/token/token-top-holders.tsx
+++ b/src/components/token/token-top-holders.tsx
@@ -1,0 +1,208 @@
+'use client'
+
+import {
+    Box,
+    Card,
+    CardHeader,
+    Chip,
+    Skeleton,
+    Stack,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    ToggleButton,
+    ToggleButtonGroup,
+    Tooltip,
+    Typography,
+    IconButton,
+} from '@mui/material'
+import { useState } from 'react'
+import useSWR from 'swr'
+import dayjs from 'dayjs'
+import { Iconify } from 'src/components/iconify'
+import { getNetwork } from 'src/hooks/get-network-storage'
+import { useGlobalContext } from 'src/provider/global-provider'
+import { endpoints, fetcher } from 'src/utils/axios'
+import { fNumber } from 'src/utils/format-number'
+import { truncateAddress, formatExplorerUrl } from 'src/config/helper'
+import type { TokenHoldersResponse } from 'src/pages/api/token/[id]/holders'
+
+type SortBy = 'volume' | 'count'
+
+function formatUsd(value: number): string {
+    if (!Number.isFinite(value)) return '$0'
+    const abs = Math.abs(value)
+    if (abs >= 1e9) return `$${(value / 1e9).toFixed(2)}B`
+    if (abs >= 1e6) return `$${(value / 1e6).toFixed(2)}M`
+    if (abs >= 1e3) return `$${(value / 1e3).toFixed(1)}k`
+    return `$${value.toFixed(2)}`
+}
+
+type Props = {
+    tokenId: number
+}
+
+export function TokenTopHolders({ tokenId }: Props) {
+    const network = getNetwork()
+    const { timePeriod } = useGlobalContext()
+    const [sortBy, setSortBy] = useState<SortBy>('volume')
+
+    const url = `${endpoints.token.holders(tokenId)}?network=${network}&period=${encodeURIComponent(
+        timePeriod,
+    )}&limit=25&sortBy=${sortBy}`
+
+    const { data, isLoading } = useSWR<TokenHoldersResponse>(url, fetcher, {
+        revalidateOnFocus: false,
+    })
+
+    const holders = data?.holders ?? []
+
+    return (
+        <Card sx={{ mt: 3 }}>
+            <CardHeader
+                title="Top Senders"
+                subheader={`Bridge activity by sender address · ${data?.total ?? 0} unique`}
+                action={
+                    <ToggleButtonGroup
+                        size="small"
+                        exclusive
+                        value={sortBy}
+                        onChange={(_, v) => v && setSortBy(v)}
+                    >
+                        <ToggleButton value="volume">By Volume</ToggleButton>
+                        <ToggleButton value="count">By Count</ToggleButton>
+                    </ToggleButtonGroup>
+                }
+            />
+            <Box sx={{ p: { xs: 1, sm: 2 }, pt: 0 }}>
+                <TableContainer>
+                    <Table size="small">
+                        <TableHead>
+                            <TableRow>
+                                <TableCell sx={{ width: 50 }}>#</TableCell>
+                                <TableCell>Address</TableCell>
+                                <TableCell align="right">Volume (USD)</TableCell>
+                                <TableCell align="right">Transfers</TableCell>
+                                <TableCell align="right">In / Out</TableCell>
+                                <TableCell align="right">Last seen</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {isLoading && !data && (
+                                <>
+                                    {Array.from({ length: 6 }).map((_, i) => (
+                                        <TableRow key={`skeleton-${i}`}>
+                                            <TableCell colSpan={6}>
+                                                <Skeleton height={28} />
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                </>
+                            )}
+                            {!isLoading && holders.length === 0 && (
+                                <TableRow>
+                                    <TableCell
+                                        colSpan={6}
+                                        align="center"
+                                        sx={{ color: 'text.secondary', py: 3 }}
+                                    >
+                                        No senders found in this period.
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                            {holders.map(h => {
+                                const chain = h.address_type === 'sui' ? 'SUI' : 'ETH'
+                                const explorerUrl = formatExplorerUrl({
+                                    network,
+                                    address: h.address,
+                                    isAccount: true,
+                                    chain,
+                                })
+                                return (
+                                    <TableRow key={`${h.address}-${h.rank}`} hover>
+                                        <TableCell>
+                                            <Typography variant="body2" fontWeight={600}>
+                                                {h.rank}
+                                            </Typography>
+                                        </TableCell>
+                                        <TableCell>
+                                            <Stack direction="row" spacing={1} alignItems="center">
+                                                <Chip
+                                                    label={chain}
+                                                    size="small"
+                                                    sx={{
+                                                        bgcolor:
+                                                            chain === 'SUI'
+                                                                ? 'rgba(77,162,255,0.15)'
+                                                                : 'rgba(98,126,234,0.15)',
+                                                        color:
+                                                            chain === 'SUI' ? '#4DA2FF' : '#627EEA',
+                                                        fontWeight: 600,
+                                                        minWidth: 44,
+                                                    }}
+                                                />
+                                                <Tooltip
+                                                    title={`0x${h.address}`}
+                                                    placement="top-start"
+                                                >
+                                                    <Typography
+                                                        variant="body2"
+                                                        fontFamily="monospace"
+                                                    >
+                                                        {truncateAddress(`0x${h.address}`, 6)}
+                                                    </Typography>
+                                                </Tooltip>
+                                                <IconButton
+                                                    size="small"
+                                                    href={explorerUrl}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                >
+                                                    <Iconify
+                                                        icon="eva:external-link-fill"
+                                                        width={14}
+                                                    />
+                                                </IconButton>
+                                            </Stack>
+                                        </TableCell>
+                                        <TableCell align="right">
+                                            <Typography variant="body2" fontWeight={600}>
+                                                {formatUsd(h.total_volume_usd)}
+                                            </Typography>
+                                        </TableCell>
+                                        <TableCell align="right">{fNumber(h.tx_count)}</TableCell>
+                                        <TableCell align="right">
+                                            <Typography variant="caption" color="success.main">
+                                                {fNumber(h.inflow_count)}
+                                            </Typography>
+                                            <Typography
+                                                variant="caption"
+                                                color="text.disabled"
+                                                sx={{ mx: 0.5 }}
+                                            >
+                                                /
+                                            </Typography>
+                                            <Typography variant="caption" color="error.main">
+                                                {fNumber(h.outflow_count)}
+                                            </Typography>
+                                        </TableCell>
+                                        <TableCell align="right">
+                                            <Typography variant="caption" color="text.secondary">
+                                                {h.last_tx_ms
+                                                    ? dayjs(h.last_tx_ms).format('MMM D, YYYY')
+                                                    : '—'}
+                                            </Typography>
+                                        </TableCell>
+                                    </TableRow>
+                                )
+                            })}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </Box>
+        </Card>
+    )
+}

--- a/src/components/token/token-volume-chart.tsx
+++ b/src/components/token/token-volume-chart.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { Card, CardHeader, Box, Stack, ToggleButton, ToggleButtonGroup } from '@mui/material'
+import { useMemo, useState } from 'react'
+import useSWR from 'swr'
+import dayjs from 'dayjs'
+import { Chart, useChart } from 'src/components/chart'
+import { getNetwork } from 'src/hooks/get-network-storage'
+import { useGlobalContext } from 'src/provider/global-provider'
+import { endpoints, fetcher } from 'src/utils/axios'
+import type { TokenVolumeResponse } from 'src/pages/api/token/[id]/volume'
+
+type Metric = 'usd' | 'count'
+
+type Props = {
+    tokenId: number
+    tokenColor: string
+}
+
+export function TokenVolumeChart({ tokenId, tokenColor }: Props) {
+    const network = getNetwork()
+    const { timePeriod } = useGlobalContext()
+    const [metric, setMetric] = useState<Metric>('usd')
+
+    const url = `${endpoints.token.volume(tokenId)}?network=${network}&period=${encodeURIComponent(
+        timePeriod,
+    )}`
+
+    const { data, isLoading } = useSWR<TokenVolumeResponse>(url, fetcher, {
+        revalidateOnFocus: false,
+    })
+
+    const { series, categories } = useMemo(() => {
+        const points = data?.points ?? []
+        const cats = points.map(p => p.bucket_ms)
+        if (metric === 'usd') {
+            return {
+                categories: cats,
+                series: [
+                    {
+                        name: 'Inflow (ETH → SUI)',
+                        data: points.map(p => Number(p.inflow_usd.toFixed(2))),
+                    },
+                    {
+                        name: 'Outflow (SUI → ETH)',
+                        data: points.map(p => -Number(p.outflow_usd.toFixed(2))),
+                    },
+                ],
+            }
+        }
+        return {
+            categories: cats,
+            series: [
+                { name: 'Inflow (ETH → SUI)', data: points.map(p => p.inflow_count) },
+                { name: 'Outflow (SUI → ETH)', data: points.map(p => -p.outflow_count) },
+            ],
+        }
+    }, [data, metric])
+
+    const granularity = data?.granularity ?? 'day'
+    const dateFmt =
+        granularity === 'hour' ? 'MMM D, HH:mm' : granularity === 'week' ? '[W of] MMM D' : 'MMM D'
+
+    const options = useChart({
+        chart: {
+            type: 'bar',
+            stacked: true,
+            toolbar: { show: false },
+            animations: { enabled: false },
+        },
+        plotOptions: {
+            bar: { columnWidth: '70%', borderRadius: 2 },
+        },
+        colors: ['#22C55E', tokenColor || '#EF4444'],
+        dataLabels: { enabled: false },
+        legend: { position: 'top', horizontalAlign: 'right' },
+        xaxis: {
+            type: 'datetime',
+            categories,
+            labels: { datetimeUTC: false },
+        },
+        yaxis: {
+            labels: {
+                formatter: (v: number) => {
+                    const abs = Math.abs(v)
+                    if (metric === 'usd') {
+                        if (abs >= 1e9) return `$${(v / 1e9).toFixed(1)}B`
+                        if (abs >= 1e6) return `$${(v / 1e6).toFixed(1)}M`
+                        if (abs >= 1e3) return `$${(v / 1e3).toFixed(1)}k`
+                        return `$${v.toFixed(0)}`
+                    }
+                    if (abs >= 1e6) return `${(v / 1e6).toFixed(1)}M`
+                    if (abs >= 1e3) return `${(v / 1e3).toFixed(1)}k`
+                    return String(v)
+                },
+            },
+        },
+        tooltip: {
+            theme: 'dark',
+            shared: true,
+            intersect: false,
+            x: {
+                formatter: (val: number) => dayjs(val).format(dateFmt),
+            },
+            y: {
+                formatter: (v: number) => {
+                    const abs = Math.abs(v)
+                    if (metric === 'usd') {
+                        return `$${abs.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
+                    }
+                    return abs.toLocaleString()
+                },
+            },
+        },
+    })
+
+    return (
+        <Card sx={{ mt: 3 }}>
+            <CardHeader
+                title="Inflow vs Outflow"
+                subheader={`Per ${granularity}`}
+                action={
+                    <Stack direction="row" spacing={1}>
+                        <ToggleButtonGroup
+                            size="small"
+                            exclusive
+                            value={metric}
+                            onChange={(_, v) => v && setMetric(v)}
+                        >
+                            <ToggleButton value="usd">USD</ToggleButton>
+                            <ToggleButton value="count">Count</ToggleButton>
+                        </ToggleButtonGroup>
+                    </Stack>
+                }
+            />
+            <Box sx={{ p: 2, pt: 0 }}>
+                <Chart
+                    type="bar"
+                    series={series}
+                    options={options}
+                    height={340}
+                    forceLoading={isLoading && !data}
+                />
+            </Box>
+        </Card>
+    )
+}

--- a/src/components/widgets/top-tokens.tsx
+++ b/src/components/widgets/top-tokens.tsx
@@ -1,6 +1,15 @@
 'use client'
 import { useMemo, useState } from 'react'
-import { Box, ButtonGroup, Button, Typography, TableRow, TableCell } from '@mui/material'
+import {
+    Box,
+    ButtonGroup,
+    Button,
+    Typography,
+    TableRow,
+    TableCell,
+    Link as MuiLink,
+} from '@mui/material'
+import NextLink from 'next/link'
 import useSWR from 'swr'
 import { endpoints, fetcher } from 'src/utils/axios'
 import { getNetwork } from 'src/hooks/get-network-storage'
@@ -9,6 +18,8 @@ import { fNumber } from 'src/utils/format-number'
 import { getTokensList } from 'src/utils/types'
 import { CustomTable } from 'src/components/table/table'
 import { downloadCsv } from 'src/utils/csv'
+import { paths } from 'src/routes/paths'
+import { getTokenMetaList } from 'src/utils/token-meta'
 
 type SortMode = 'usd' | 'count'
 
@@ -213,27 +224,61 @@ export default function TopTokens() {
                     { id: 'uniqueAddresses', label: 'Unique addresses', align: 'right' },
                 ]}
                 tableData={rows}
-                RowComponent={({ row }) => (
-                    <TableRow hover>
-                        <TableCell>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                                {row.icon ? (
-                                    // eslint-disable-next-line @next/next/no-img-element
-                                    <img src={row.icon} alt={row.token} width={18} height={18} />
-                                ) : null}
-                                {row.token}
-                            </Box>
-                        </TableCell>
-                        <TableCell align="right">${fNumber(row.inflowUsd)}</TableCell>
-                        <TableCell align="right">${fNumber(row.outflowUsd)}</TableCell>
-                        <TableCell align="right">${fNumber(row.netUsd)}</TableCell>
-                        <TableCell align="right">{fNumber(row.sharePct)}%</TableCell>
-                        <TableCell align="right">
-                            {fNumber(row.inflowCount)}/{fNumber(row.outflowCount)}
-                        </TableCell>
-                        <TableCell align="right">{fNumber(row.uniqueAddresses || 0)}</TableCell>
-                    </TableRow>
-                )}
+                RowComponent={({ row }) => {
+                    const tokenMeta = getTokenMetaList(network).find(t => t.ticker === row.token)
+                    return (
+                        <TableRow hover>
+                            <TableCell>
+                                {tokenMeta ? (
+                                    <MuiLink
+                                        component={NextLink}
+                                        href={paths.tokens.details(tokenMeta.id)}
+                                        underline="hover"
+                                        color="inherit"
+                                        sx={{
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            gap: 1,
+                                            fontWeight: 500,
+                                        }}
+                                    >
+                                        {row.icon ? (
+                                            // eslint-disable-next-line @next/next/no-img-element
+                                            <img
+                                                src={row.icon}
+                                                alt={row.token}
+                                                width={18}
+                                                height={18}
+                                            />
+                                        ) : null}
+                                        {row.token}
+                                    </MuiLink>
+                                ) : (
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                        {row.icon ? (
+                                            // eslint-disable-next-line @next/next/no-img-element
+                                            <img
+                                                src={row.icon}
+                                                alt={row.token}
+                                                width={18}
+                                                height={18}
+                                            />
+                                        ) : null}
+                                        {row.token}
+                                    </Box>
+                                )}
+                            </TableCell>
+                            <TableCell align="right">${fNumber(row.inflowUsd)}</TableCell>
+                            <TableCell align="right">${fNumber(row.outflowUsd)}</TableCell>
+                            <TableCell align="right">${fNumber(row.netUsd)}</TableCell>
+                            <TableCell align="right">{fNumber(row.sharePct)}%</TableCell>
+                            <TableCell align="right">
+                                {fNumber(row.inflowCount)}/{fNumber(row.outflowCount)}
+                            </TableCell>
+                            <TableCell align="right">{fNumber(row.uniqueAddresses || 0)}</TableCell>
+                        </TableRow>
+                    )
+                }}
                 loading={isLoading}
                 hidePagination
                 rowHeight={60}

--- a/src/layouts/components/nav-tabs.tsx
+++ b/src/layouts/components/nav-tabs.tsx
@@ -41,6 +41,11 @@ const NAV_ITEMS = [
         icon: icon('ic-ecommerce'),
     },
     {
+        label: 'Tokens',
+        path: paths.tokens.root,
+        icon: icon('ic-label'),
+    },
+    {
         label: 'Leaderboard',
         path: paths.leaderboard.root,
         icon: icon('ic-tour'),
@@ -80,8 +85,8 @@ export function NavTabs() {
                 },
                 '& .MuiTab-root': {
                     minHeight: 48,
-                    minWidth: 120,
-                    px: 2.5,
+                    minWidth: 'auto',
+                    px: 2,
                     fontWeight: 700,
                     fontSize: '0.875rem',
                     textTransform: 'none',

--- a/src/layouts/config-nav-dashboard.tsx
+++ b/src/layouts/config-nav-dashboard.tsx
@@ -58,6 +58,10 @@ export const navData = [
     },
 
     {
+        items: [{ title: 'Tokens', path: paths.tokens.root, icon: ICONS.label }],
+    },
+
+    {
         items: [{ title: 'Leaderboard', path: paths.leaderboard.root, icon: ICONS.order }],
     },
 

--- a/src/pages/api/token/[id]/holders.ts
+++ b/src/pages/api/token/[id]/holders.ts
@@ -1,0 +1,115 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getNetworkConfig, TimePeriod } from 'src/config/helper'
+import { sendError, sendReply } from '../../utils'
+import db from '../../database'
+import { computerIntervals } from '../../cards'
+
+export type TokenHolderRow = {
+    rank: number
+    address: string
+    address_type: 'sui' | 'eth'
+    total_volume_usd: number
+    total_volume_raw: number
+    tx_count: number
+    inflow_count: number
+    outflow_count: number
+    first_tx_ms: number
+    last_tx_ms: number
+}
+
+export type TokenHoldersResponse = {
+    token_id: number
+    period: TimePeriod
+    total: number
+    holders: TokenHolderRow[]
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        const networkConfig = getNetworkConfig({ req })
+        const timePeriod = (req.query.period as TimePeriod) || 'Last Month'
+        const tokenId = Number(req.query.id)
+        const limit = Math.min(Number(req.query.limit) || 25, 100)
+        const offset = Number(req.query.offset) || 0
+        const sortBy = (req.query.sortBy as 'volume' | 'count') || 'volume'
+
+        if (!Number.isFinite(tokenId)) {
+            sendError(res, { code: 400, message: 'Invalid token id' })
+            return
+        }
+
+        const { fromInterval, toInterval } = computerIntervals(timePeriod, false)
+        const sql = db[networkConfig.network]
+
+        const SUI_ID = networkConfig.config.networkId.SUI
+
+        const orderBy =
+            sortBy === 'count'
+                ? sql`tx_count DESC NULLS LAST`
+                : sql`total_volume_usd DESC NULLS LAST`
+
+        const [holdersQuery, countQuery] = await Promise.all([
+            sql`
+                WITH per_address AS (
+                    SELECT
+                        encode(t.sender_address, 'hex') AS address,
+                        SUM(CASE WHEN t.destination_chain = ${SUI_ID} THEN 1 ELSE 0 END)::BIGINT AS inflow_count,
+                        SUM(CASE WHEN t.destination_chain <> ${SUI_ID} THEN 1 ELSE 0 END)::BIGINT AS outflow_count,
+                        COUNT(*)::BIGINT AS tx_count,
+                        COALESCE(SUM(t.amount), 0) AS total_volume_raw,
+                        COALESCE(SUM((t.amount::NUMERIC / p.denominator) * p.price::FLOAT8), 0) AS total_volume_usd,
+                        MIN(t.timestamp_ms) AS first_tx_ms,
+                        MAX(t.timestamp_ms) AS last_tx_ms,
+                        CASE
+                            WHEN SUM(CASE WHEN t.destination_chain = ${SUI_ID} THEN 1 ELSE 0 END) >
+                                 SUM(CASE WHEN t.destination_chain <> ${SUI_ID} THEN 1 ELSE 0 END)
+                            THEN 'eth'
+                            ELSE 'sui'
+                        END AS address_type
+                    FROM public.token_transfer_data t
+                    JOIN public.prices p ON p.token_id = t.token_id
+                    WHERE t.is_finalized = true
+                      AND t.token_id = ${tokenId}
+                      AND t.sender_address IS NOT NULL
+                      AND t.timestamp_ms BETWEEN ${fromInterval} AND ${toInterval}
+                    GROUP BY 1
+                )
+                SELECT *
+                FROM per_address
+                ORDER BY ${orderBy}
+                LIMIT ${limit} OFFSET ${offset}
+            `,
+            sql`
+                SELECT COUNT(DISTINCT t.sender_address)::BIGINT AS total
+                FROM public.token_transfer_data t
+                WHERE t.is_finalized = true
+                  AND t.token_id = ${tokenId}
+                  AND t.sender_address IS NOT NULL
+                  AND t.timestamp_ms BETWEEN ${fromInterval} AND ${toInterval}
+            `,
+        ])
+
+        const holders: TokenHolderRow[] = (holdersQuery as any[]).map((row: any, idx: number) => ({
+            rank: offset + idx + 1,
+            address: row.address,
+            address_type: row.address_type as 'sui' | 'eth',
+            total_volume_usd: Number(row.total_volume_usd) || 0,
+            total_volume_raw: Number(row.total_volume_raw) || 0,
+            tx_count: Number(row.tx_count) || 0,
+            inflow_count: Number(row.inflow_count) || 0,
+            outflow_count: Number(row.outflow_count) || 0,
+            first_tx_ms: Number(row.first_tx_ms) || 0,
+            last_tx_ms: Number(row.last_tx_ms) || 0,
+        }))
+
+        sendReply(res, {
+            token_id: tokenId,
+            period: timePeriod,
+            total: Number((countQuery as any[])[0]?.total) || 0,
+            holders,
+        } as TokenHoldersResponse)
+    } catch (error) {
+        console.error('Token holders API error:', error)
+        sendError(res, error)
+    }
+}

--- a/src/pages/api/token/[id]/overview.ts
+++ b/src/pages/api/token/[id]/overview.ts
@@ -1,0 +1,174 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getNetworkConfig, TimePeriod } from 'src/config/helper'
+import { sendError, sendReply } from '../../utils'
+import db from '../../database'
+import { computerIntervals } from '../../cards'
+
+export type TokenOverviewResponse = {
+    token_id: number
+    token_name: string
+    price_usd: number
+    decimals: number
+    period: TimePeriod
+    totals: {
+        total_volume_usd: number
+        total_volume_raw: number
+        total_tx_count: number
+        unique_senders: number
+        unique_recipients: number
+        avg_tx_usd: number
+        max_tx_usd: number
+        min_tx_usd: number
+        first_tx_ms: number | null
+        last_tx_ms: number | null
+    }
+    direction: {
+        inflow_usd: number
+        outflow_usd: number
+        inflow_count: number
+        outflow_count: number
+        net_usd: number
+    }
+    previous: {
+        total_volume_usd: number
+        total_tx_count: number
+        unique_senders: number
+    }
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        const networkConfig = getNetworkConfig({ req })
+        const timePeriod = (req.query.period as TimePeriod) || 'Last Month'
+        const tokenId = Number(req.query.id)
+
+        if (!Number.isFinite(tokenId)) {
+            sendError(res, { code: 400, message: 'Invalid token id' })
+            return
+        }
+
+        const tokenMeta = networkConfig.config.coins[tokenId]
+        if (!tokenMeta) {
+            sendError(res, { code: 404, message: 'Token not found' })
+            return
+        }
+
+        const { fromInterval, toInterval } = computerIntervals(timePeriod, false)
+        const { fromInterval: prevFrom, toInterval: prevTo } = computerIntervals(timePeriod, true)
+        const sql = db[networkConfig.network]
+
+        // Run queries in parallel
+        const [priceRow, currentRow, directionRows, previousRow] = await Promise.all([
+            sql`
+                SELECT price, denominator
+                FROM public.prices
+                WHERE token_id = ${tokenId}
+                LIMIT 1
+            `,
+            sql`
+                SELECT
+                    COUNT(*)::BIGINT                                                AS tx_count,
+                    COUNT(DISTINCT t.sender_address)::BIGINT                        AS unique_senders,
+                    COUNT(DISTINCT t.recipient_address)::BIGINT                     AS unique_recipients,
+                    COALESCE(SUM(t.amount), 0)                                      AS total_volume_raw,
+                    COALESCE(SUM((t.amount::NUMERIC / p.denominator) * p.price::FLOAT8), 0) AS total_volume_usd,
+                    COALESCE(AVG((t.amount::NUMERIC / p.denominator) * p.price::FLOAT8), 0) AS avg_tx_usd,
+                    COALESCE(MAX((t.amount::NUMERIC / p.denominator) * p.price::FLOAT8), 0) AS max_tx_usd,
+                    COALESCE(MIN((t.amount::NUMERIC / p.denominator) * p.price::FLOAT8), 0) AS min_tx_usd,
+                    MIN(t.timestamp_ms)                                             AS first_tx_ms,
+                    MAX(t.timestamp_ms)                                             AS last_tx_ms
+                FROM public.token_transfer_data t
+                JOIN public.prices p ON p.token_id = t.token_id
+                WHERE t.is_finalized = true
+                  AND t.token_id = ${tokenId}
+                  AND t.timestamp_ms BETWEEN ${fromInterval} AND ${toInterval}
+            `,
+            sql`
+                SELECT
+                    t.destination_chain,
+                    COUNT(*)::BIGINT                                                AS tx_count,
+                    COALESCE(SUM((t.amount::NUMERIC / p.denominator) * p.price::FLOAT8), 0) AS volume_usd
+                FROM public.token_transfer_data t
+                JOIN public.prices p ON p.token_id = t.token_id
+                WHERE t.is_finalized = true
+                  AND t.token_id = ${tokenId}
+                  AND t.timestamp_ms BETWEEN ${fromInterval} AND ${toInterval}
+                GROUP BY t.destination_chain
+            `,
+            sql`
+                SELECT
+                    COUNT(*)::BIGINT                                                AS tx_count,
+                    COUNT(DISTINCT t.sender_address)::BIGINT                        AS unique_senders,
+                    COALESCE(SUM((t.amount::NUMERIC / p.denominator) * p.price::FLOAT8), 0) AS total_volume_usd
+                FROM public.token_transfer_data t
+                JOIN public.prices p ON p.token_id = t.token_id
+                WHERE t.is_finalized = true
+                  AND t.token_id = ${tokenId}
+                  AND t.timestamp_ms BETWEEN ${prevFrom} AND ${prevTo}
+            `,
+        ])
+
+        const cur = (currentRow as any[])[0] ?? {}
+        const prev = (previousRow as any[])[0] ?? {}
+
+        const SUI_ID = networkConfig.config.networkId.SUI
+        const ETH_ID = networkConfig.config.networkId.ETH
+
+        let inflowUsd = 0,
+            outflowUsd = 0,
+            inflowCount = 0,
+            outflowCount = 0
+        for (const row of directionRows as any[]) {
+            const dst = Number(row.destination_chain)
+            const usd = Number(row.volume_usd) || 0
+            const cnt = Number(row.tx_count) || 0
+            // inflow = into SUI (destination is SUI)
+            if (dst === SUI_ID) {
+                inflowUsd += usd
+                inflowCount += cnt
+            } else if (dst === ETH_ID) {
+                outflowUsd += usd
+                outflowCount += cnt
+            }
+        }
+
+        const priceMeta = (priceRow as any[])[0] ?? {}
+
+        const response: TokenOverviewResponse = {
+            token_id: tokenId,
+            token_name: tokenMeta.name,
+            price_usd: Number(priceMeta.price) || 0,
+            decimals: Math.log10(tokenMeta.deno) || 0,
+            period: timePeriod,
+            totals: {
+                total_volume_usd: Number(cur.total_volume_usd) || 0,
+                total_volume_raw: Number(cur.total_volume_raw) || 0,
+                total_tx_count: Number(cur.tx_count) || 0,
+                unique_senders: Number(cur.unique_senders) || 0,
+                unique_recipients: Number(cur.unique_recipients) || 0,
+                avg_tx_usd: Number(cur.avg_tx_usd) || 0,
+                max_tx_usd: Number(cur.max_tx_usd) || 0,
+                min_tx_usd: Number(cur.min_tx_usd) || 0,
+                first_tx_ms: cur.first_tx_ms ? Number(cur.first_tx_ms) : null,
+                last_tx_ms: cur.last_tx_ms ? Number(cur.last_tx_ms) : null,
+            },
+            direction: {
+                inflow_usd: inflowUsd,
+                outflow_usd: outflowUsd,
+                inflow_count: inflowCount,
+                outflow_count: outflowCount,
+                net_usd: inflowUsd - outflowUsd,
+            },
+            previous: {
+                total_volume_usd: Number(prev.total_volume_usd) || 0,
+                total_tx_count: Number(prev.tx_count) || 0,
+                unique_senders: Number(prev.unique_senders) || 0,
+            },
+        }
+
+        sendReply(res, response)
+    } catch (error) {
+        console.error('Token overview API error:', error)
+        sendError(res, error)
+    }
+}

--- a/src/pages/api/token/[id]/size-histogram.ts
+++ b/src/pages/api/token/[id]/size-histogram.ts
@@ -1,0 +1,77 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getNetworkConfig, TimePeriod } from 'src/config/helper'
+import { sendError, sendReply } from '../../utils'
+import db from '../../database'
+import { computerIntervals } from '../../cards'
+
+export type TokenSizeBucket = {
+    bucket: string
+    bucket_order: number
+    count: number
+    usd: number
+}
+
+/**
+ * Per-token size histogram. Buckets transfers by their USD value.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        const networkConfig = getNetworkConfig({ req })
+        const timePeriod = (req.query.period as TimePeriod) || 'Last Month'
+        const tokenId = Number(req.query.id)
+
+        if (!Number.isFinite(tokenId)) {
+            sendError(res, { code: 400, message: 'Invalid token id' })
+            return
+        }
+
+        const { fromInterval, toInterval } = computerIntervals(timePeriod, false)
+        const sql = db[networkConfig.network]
+
+        const rows = await sql`
+            WITH txs AS (
+                SELECT
+                    (t.amount::NUMERIC / p.denominator) * p.price::FLOAT8 AS usd
+                FROM public.token_transfer_data t
+                JOIN public.prices p ON p.token_id = t.token_id
+                WHERE t.is_finalized = true
+                  AND t.token_id = ${tokenId}
+                  AND t.timestamp_ms BETWEEN ${fromInterval} AND ${toInterval}
+            )
+            SELECT
+                CASE
+                    WHEN usd <      100  THEN '< $100'
+                    WHEN usd <     1000  THEN '$100 – $1k'
+                    WHEN usd <    10000  THEN '$1k – $10k'
+                    WHEN usd <   100000  THEN '$10k – $100k'
+                    WHEN usd <  1000000  THEN '$100k – $1M'
+                    ELSE                      '$1M+'
+                END AS bucket,
+                CASE
+                    WHEN usd <      100  THEN 1
+                    WHEN usd <     1000  THEN 2
+                    WHEN usd <    10000  THEN 3
+                    WHEN usd <   100000  THEN 4
+                    WHEN usd <  1000000  THEN 5
+                    ELSE                      6
+                END AS bucket_order,
+                COUNT(*) AS count,
+                COALESCE(SUM(usd), 0) AS usd
+            FROM txs
+            GROUP BY 1, 2
+            ORDER BY bucket_order
+        `
+
+        const data: TokenSizeBucket[] = (rows as any[]).map(r => ({
+            bucket: String(r.bucket),
+            bucket_order: Number(r.bucket_order),
+            count: Number(r.count) || 0,
+            usd: Number(r.usd) || 0,
+        }))
+
+        sendReply(res, data)
+    } catch (error) {
+        console.error('Token size-histogram API error:', error)
+        sendError(res, error)
+    }
+}

--- a/src/pages/api/token/[id]/volume.ts
+++ b/src/pages/api/token/[id]/volume.ts
@@ -1,0 +1,101 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getNetworkConfig, TimePeriod } from 'src/config/helper'
+import { sendError, sendReply } from '../../utils'
+import db from '../../database'
+import { computerIntervals } from '../../cards'
+
+export type TokenVolumePoint = {
+    bucket_ms: number
+    inflow_usd: number
+    outflow_usd: number
+    inflow_count: number
+    outflow_count: number
+}
+
+export type TokenVolumeResponse = {
+    token_id: number
+    period: TimePeriod
+    granularity: 'hour' | 'day' | 'week'
+    points: TokenVolumePoint[]
+}
+
+const getGranularity = (period: TimePeriod): 'hour' | 'day' | 'week' => {
+    if (period === 'Last 24h') return 'hour'
+    if (period === 'Last Week') return 'hour'
+    if (period === 'Last 6 months' || period === 'Last year' || period === 'All time') return 'week'
+    return 'day'
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        const networkConfig = getNetworkConfig({ req })
+        const timePeriod = (req.query.period as TimePeriod) || 'Last Month'
+        const tokenId = Number(req.query.id)
+
+        if (!Number.isFinite(tokenId)) {
+            sendError(res, { code: 400, message: 'Invalid token id' })
+            return
+        }
+
+        const { fromInterval, toInterval } = computerIntervals(timePeriod, false)
+        const granularity = getGranularity(timePeriod)
+        const sql = db[networkConfig.network]
+
+        const truncSpec = granularity === 'hour' ? 'hour' : granularity === 'week' ? 'week' : 'day'
+
+        const SUI_ID = networkConfig.config.networkId.SUI
+
+        const rows = await sql`
+            SELECT
+                (EXTRACT(EPOCH FROM DATE_TRUNC(${truncSpec}, TO_TIMESTAMP(t.timestamp_ms / 1000))) * 1000)::BIGINT AS bucket_ms,
+                CASE WHEN t.destination_chain = ${SUI_ID} THEN 'inflow' ELSE 'outflow' END AS direction,
+                COUNT(*)::BIGINT AS tx_count,
+                COALESCE(SUM((t.amount::NUMERIC / p.denominator) * p.price::FLOAT8), 0) AS volume_usd
+            FROM public.token_transfer_data t
+            JOIN public.prices p ON p.token_id = t.token_id
+            WHERE t.is_finalized = true
+              AND t.token_id = ${tokenId}
+              AND t.timestamp_ms BETWEEN ${fromInterval} AND ${toInterval}
+            GROUP BY 1, 2
+            ORDER BY 1 ASC
+        `
+
+        // Pivot to per-bucket inflow/outflow
+        const byBucket: Record<number, TokenVolumePoint> = {}
+        for (const row of rows as any[]) {
+            const ms = Number(row.bucket_ms)
+            if (!byBucket[ms]) {
+                byBucket[ms] = {
+                    bucket_ms: ms,
+                    inflow_usd: 0,
+                    outflow_usd: 0,
+                    inflow_count: 0,
+                    outflow_count: 0,
+                }
+            }
+            const usd = Number(row.volume_usd) || 0
+            const cnt = Number(row.tx_count) || 0
+            if (row.direction === 'inflow') {
+                byBucket[ms].inflow_usd += usd
+                byBucket[ms].inflow_count += cnt
+            } else {
+                byBucket[ms].outflow_usd += usd
+                byBucket[ms].outflow_count += cnt
+            }
+        }
+
+        const points = Object.values(byBucket).sort((a, b) => a.bucket_ms - b.bucket_ms)
+
+        const response: TokenVolumeResponse = {
+            token_id: tokenId,
+            period: timePeriod,
+            granularity,
+            points,
+        }
+
+        sendReply(res, response)
+    } catch (error) {
+        console.error('Token volume API error:', error)
+        sendError(res, error)
+    }
+}

--- a/src/pages/api/token/summary.ts
+++ b/src/pages/api/token/summary.ts
@@ -1,0 +1,93 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getNetworkConfig, TimePeriod } from 'src/config/helper'
+import { sendError, sendReply } from '../utils'
+import db from '../database'
+import { computerIntervals } from '../cards'
+
+export type TokenSummaryRow = {
+    token_id: number
+    inflow_usd: number
+    outflow_usd: number
+    inflow_count: number
+    outflow_count: number
+    total_volume_usd: number
+    total_tx_count: number
+    unique_senders: number
+    avg_tx_usd: number
+    max_tx_usd: number
+    prev_total_volume_usd: number
+}
+
+export type TokenSummaryResponse = {
+    period: TimePeriod
+    rows: TokenSummaryRow[]
+}
+
+const aggregateQuery = (sql: any, SUI_ID: number, from: number, to: number) => sql`
+    WITH base AS (
+        SELECT
+            t.token_id,
+            t.destination_chain,
+            t.amount,
+            t.sender_address
+        FROM public.token_transfer_data t
+        WHERE t.is_finalized = true
+          AND t.timestamp_ms BETWEEN ${from} AND ${to}
+    )
+    SELECT
+        b.token_id,
+        SUM(CASE WHEN b.destination_chain = ${SUI_ID} THEN (b.amount::NUMERIC / p.denominator) * p.price::FLOAT8 ELSE 0 END) AS inflow_usd,
+        SUM(CASE WHEN b.destination_chain <> ${SUI_ID} THEN (b.amount::NUMERIC / p.denominator) * p.price::FLOAT8 ELSE 0 END) AS outflow_usd,
+        SUM(CASE WHEN b.destination_chain = ${SUI_ID} THEN 1 ELSE 0 END)::BIGINT AS inflow_count,
+        SUM(CASE WHEN b.destination_chain <> ${SUI_ID} THEN 1 ELSE 0 END)::BIGINT AS outflow_count,
+        COUNT(*)::BIGINT AS total_tx_count,
+        COUNT(DISTINCT b.sender_address)::BIGINT AS unique_senders,
+        COALESCE(SUM((b.amount::NUMERIC / p.denominator) * p.price::FLOAT8), 0) AS total_volume_usd,
+        COALESCE(AVG((b.amount::NUMERIC / p.denominator) * p.price::FLOAT8), 0) AS avg_tx_usd,
+        COALESCE(MAX((b.amount::NUMERIC / p.denominator) * p.price::FLOAT8), 0) AS max_tx_usd
+    FROM base b
+    LEFT JOIN public.prices p ON p.token_id = b.token_id
+    GROUP BY b.token_id
+`
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        const networkConfig = getNetworkConfig({ req })
+        const timePeriod = (req.query.period as TimePeriod) || 'Last Month'
+
+        const { fromInterval, toInterval } = computerIntervals(timePeriod, false)
+        const { fromInterval: prevFrom, toInterval: prevTo } = computerIntervals(timePeriod, true)
+
+        const sql = db[networkConfig.network]
+        const SUI_ID = networkConfig.config.networkId.SUI
+
+        const [current, previous] = await Promise.all([
+            aggregateQuery(sql, SUI_ID, fromInterval, toInterval),
+            aggregateQuery(sql, SUI_ID, prevFrom, prevTo),
+        ])
+
+        const prevByToken: Record<number, number> = {}
+        for (const row of previous as any[]) {
+            prevByToken[Number(row.token_id)] = Number(row.total_volume_usd) || 0
+        }
+
+        const rows: TokenSummaryRow[] = (current as any[]).map((row: any) => ({
+            token_id: Number(row.token_id),
+            inflow_usd: Number(row.inflow_usd) || 0,
+            outflow_usd: Number(row.outflow_usd) || 0,
+            inflow_count: Number(row.inflow_count) || 0,
+            outflow_count: Number(row.outflow_count) || 0,
+            total_volume_usd: Number(row.total_volume_usd) || 0,
+            total_tx_count: Number(row.total_tx_count) || 0,
+            unique_senders: Number(row.unique_senders) || 0,
+            avg_tx_usd: Number(row.avg_tx_usd) || 0,
+            max_tx_usd: Number(row.max_tx_usd) || 0,
+            prev_total_volume_usd: prevByToken[Number(row.token_id)] || 0,
+        }))
+
+        sendReply(res, { period: timePeriod, rows } as TokenSummaryResponse)
+    } catch (error) {
+        console.error('Token summary API error:', error)
+        sendError(res, error)
+    }
+}

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -7,6 +7,7 @@ const ROOTS = {
     PROFILE: '/profile',
     LEADERBOARD: '/leaderboard',
     FLOWS: '/flows',
+    TOKENS: '/tokens',
 }
 
 // ----------------------------------------------------------------------
@@ -74,5 +75,11 @@ export const paths = {
     // FLOWS
     flows: {
         root: ROOTS.FLOWS,
+    },
+
+    // TOKENS
+    tokens: {
+        root: ROOTS.TOKENS,
+        details: (id: number | string) => `${ROOTS.TOKENS}/${id}`,
     },
 }

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -54,4 +54,11 @@ export const endpoints = {
     },
     flows: '/api/flows',
     sizeHistogram: '/api/size-histogram',
+    token: {
+        summary: '/api/token/summary',
+        overview: (id: number) => `/api/token/${id}/overview`,
+        volume: (id: number) => `/api/token/${id}/volume`,
+        holders: (id: number) => `/api/token/${id}/holders`,
+        sizeHistogram: (id: number) => `/api/token/${id}/size-histogram`,
+    },
 }

--- a/src/utils/token-meta.ts
+++ b/src/utils/token-meta.ts
@@ -1,0 +1,78 @@
+import { NETWORK } from 'src/hooks/get-network-storage'
+import { getNetworkConfig } from 'src/config/helper'
+import { getTokensList, TokenColorInfo } from 'src/utils/types'
+
+/**
+ * Combined token metadata: id + ticker + display color + icon (when available).
+ * Used by `/tokens` listing and token drilldown pages.
+ */
+export type TokenMeta = {
+    id: number
+    ticker: string
+    name: string
+    color: string
+    icon?: string
+    decimals: number
+    coingeckoId: string
+}
+
+/**
+ * Build a list of TokenMeta entries for a given network.
+ * Only includes tokens that are actually bridged on that network
+ * (i.e. present in the UI token list). This keeps the listing
+ * consistent with pie charts / top-tokens / sankey on the same network.
+ */
+export function getTokenMetaList(network: NETWORK): TokenMeta[] {
+    const config = getNetworkConfig({ network }).config
+    const uiList: TokenColorInfo[] = getTokensList(network)
+    const coinsByTicker: Record<string, { id: number; deno: number; coingeckoId: string }> = {}
+    for (const coin of Object.values(config.coins)) {
+        coinsByTicker[coin.name] = {
+            id: coin.id,
+            deno: coin.deno,
+            coingeckoId: coin.coingeckoId,
+        }
+    }
+
+    return uiList
+        .map((ui): TokenMeta | null => {
+            const coin = coinsByTicker[ui.ticker]
+            if (!coin) return null
+            return {
+                id: coin.id,
+                ticker: ui.ticker,
+                name: ui.name,
+                color: ui.color,
+                icon: ui.icon,
+                decimals: Math.log10(coin.deno) || 0,
+                coingeckoId: coin.coingeckoId,
+            }
+        })
+        .filter((t): t is TokenMeta => t !== null)
+}
+
+/**
+ * Look up a token by id. Falls back to the raw network config
+ * so /tokens/[id] still works for tokens that aren't in the UI list
+ * (e.g. opening a USDC link while on mainnet).
+ */
+export function getTokenMeta(network: NETWORK, id: number | string): TokenMeta | undefined {
+    const numericId = Number(id)
+    const list = getTokenMetaList(network)
+    const found = list.find(t => t.id === numericId)
+    if (found) return found
+
+    // Fallback: build a minimal meta from the network config if available
+    const config = getNetworkConfig({ network }).config
+    const coin = config.coins[numericId]
+    if (!coin) return undefined
+    return {
+        id: coin.id,
+        ticker: coin.name,
+        name: coin.name,
+        color: '#a78bfa',
+        icon: undefined,
+        decimals: Math.log10(coin.deno) || 0,
+        coingeckoId: coin.coingeckoId,
+    }
+}


### PR DESCRIPTION
## Summary

- New **/tokens** listing page (4-up card grid) showing per-token total volume, inflow, outflow and transfer count for the active period
- New **/tokens/[id]** drilldown page with: overview stats (volume, transfers, unique senders, net flow, avg/max/min, vs previous period), inflow vs outflow time series, top senders table with explorer links, and per-token transfer-size distribution
- Tokens are now reachable from both the top nav bar and the side nav; Top Tokens widget on the dashboard now links into the drilldown
- Refactored the inflow / outflow labelling across the feature so the direction is unambiguous (`ETH → SUI` / `SUI → ETH`), to clear up the "ETH outflow to ETH" confusion

## API endpoints added

| Endpoint | Purpose |
|---|---|
| `GET /api/token/summary` | Aggregated per-token stats for the active period (used by `/tokens`) |
| `GET /api/token/[id]/overview` | Totals, direction split, vs previous period |
| `GET /api/token/[id]/volume` | Bucketed inflow/outflow time series (hour/day/week auto) |
| `GET /api/token/[id]/holders` | Top senders by volume or count |
| `GET /api/token/[id]/size-histogram` | Per-token USD size buckets |

All queries filter the transfers table first (`is_finalized` + `timestamp_ms` window) and then `LEFT JOIN prices`, so tokens missing a price row still show up and the testnet DB does not stall on the join.

## Frontend

- Listing page (`/tokens`) — 4 cards per row on desktop, sorted by volume desc. Memoized token list per network, SWR with `shouldRetryOnError: false` and a clear error card, so a slow/failing testnet query no longer produces an endless skeleton loop
- Drilldown page (`/tokens/[id]`) — overview stat tiles with % vs previous period, inflow/outflow stacked-bar time series (USD / count toggle), top senders table (with chain badge + truncated address + explorer link + sort by volume or count), per-token size histogram
- New shared `src/utils/token-meta.ts` unifies API token config + UI token list, so `/tokens` only lists tokens that are actually bridged on the active network (no more zero-value zombie rows on mainnet). Deep links to any token id still resolve via a fallback lookup
- Tokens entry added to `nav-tabs.tsx` (top nav, desktop + mobile) and `config-nav-dashboard.tsx` (side nav)

## Test plan

- [x] `yarn tsc --noEmit` passes
- [x] `yarn build` passes (verified `/tokens`, `/tokens/[id]` and all 5 token APIs are listed in the build output)
- [ ] Manual: open `/tokens` on mainnet and testnet, click a token, change the global time period and verify cards / charts update
- [ ] Manual: hover the inflow / outflow labels and confirm the tooltip wording is correct
- [ ] Manual: switch network on the drilldown — page should rehydrate cleanly (no stuck loading)