### PR TITLE
Global search (⌘K) + copy-to-clipboard polish

### DIFF
--- a/src/components/copy-button/copy-button.tsx
+++ b/src/components/copy-button/copy-button.tsx
@@ -1,0 +1,49 @@
+import { IconButton, Tooltip } from '@mui/material'
+import { useRef, useState } from 'react'
+import { Iconify } from '../iconify'
+
+// ----------------------------------------------------------------------
+
+type CopyButtonProps = {
+    /** The full value to copy to the clipboard */
+    value: string
+    /** Tooltip label shown before copying (default: "Copy") */
+    title?: string
+    /** Icon size in px (default: 16) */
+    size?: number
+}
+
+/**
+ * Small icon button that copies `value` to the clipboard and gives
+ * visual feedback (checkmark + "Copied!" tooltip) for 2 seconds.
+ */
+export function CopyButton({ value, title = 'Copy', size = 16 }: CopyButtonProps) {
+    const [copied, setCopied] = useState(false)
+    const timeoutRef = useRef<ReturnType<typeof setTimeout>>()
+
+    const handleCopy = async (event: React.MouseEvent) => {
+        event.stopPropagation()
+        try {
+            await navigator.clipboard.writeText(value)
+            setCopied(true)
+            if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current)
+            }
+            timeoutRef.current = setTimeout(() => setCopied(false), 2000)
+        } catch (error) {
+            console.error('Failed to copy to clipboard:', error)
+        }
+    }
+
+    return (
+        <Tooltip title={copied ? 'Copied!' : title}>
+            <IconButton
+                size="small"
+                onClick={handleCopy}
+                sx={{ color: copied ? 'success.main' : 'text.secondary' }}
+            >
+                <Iconify icon={copied ? 'eva:checkmark-fill' : 'eva:copy-outline'} width={size} />
+            </IconButton>
+        </Tooltip>
+    )
+}

--- a/src/components/copy-button/index.ts
+++ b/src/components/copy-button/index.ts
@@ -1,0 +1,1 @@
+export * from './copy-button'

--- a/src/components/leaderboard/address-cell.tsx
+++ b/src/components/leaderboard/address-cell.tsx
@@ -1,7 +1,6 @@
-import { Box, IconButton, Tooltip, Typography } from '@mui/material'
+import { Box, Tooltip, Typography } from '@mui/material'
 import { useTheme, alpha } from '@mui/material/styles'
-import { useState } from 'react'
-import { Iconify } from 'src/components/iconify'
+import { CopyButton } from 'src/components/copy-button'
 import { truncateAddress } from 'src/config/helper'
 
 interface AddressCellProps {
@@ -12,19 +11,6 @@ interface AddressCellProps {
 
 export function AddressCell({ address, addressType, onClick }: AddressCellProps) {
     const theme = useTheme()
-    const [copied, setCopied] = useState(false)
-
-    const handleCopy = async (e: React.MouseEvent) => {
-        e.stopPropagation()
-        try {
-            const fullAddress = `0x${address}`
-            await navigator.clipboard.writeText(fullAddress)
-            setCopied(true)
-            setTimeout(() => setCopied(false), 2000)
-        } catch (err) {
-            console.error('Failed to copy address:', err)
-        }
-    }
 
     const chainColor = addressType === 'sui' ? '#4DA2FF' : '#627EEA'
     const chainIcon =
@@ -80,22 +66,7 @@ export function AddressCell({ address, addressType, onClick }: AddressCellProps)
             </Typography>
 
             {/* Copy button */}
-            <Tooltip title={copied ? 'Copied!' : 'Copy address'}>
-                <IconButton
-                    size="small"
-                    onClick={handleCopy}
-                    sx={{
-                        ml: 0.5,
-                        p: 0.5,
-                        color: copied ? 'success.main' : 'text.secondary',
-                        '&:hover': {
-                            bgcolor: alpha(theme.palette.primary.main, 0.08),
-                        },
-                    }}
-                >
-                    <Iconify icon={copied ? 'eva:checkmark-fill' : 'eva:copy-fill'} width={16} />
-                </IconButton>
-            </Tooltip>
+            <CopyButton value={`0x${address}`} title="Copy address" />
         </Box>
     )
 }

--- a/src/components/token/token-top-holders.tsx
+++ b/src/components/token/token-top-holders.tsx
@@ -22,6 +22,7 @@ import {
 import { useState } from 'react'
 import useSWR from 'swr'
 import dayjs from 'dayjs'
+import { CopyButton } from 'src/components/copy-button'
 import { Iconify } from 'src/components/iconify'
 import { getNetwork } from 'src/hooks/get-network-storage'
 import { useGlobalContext } from 'src/provider/global-provider'
@@ -148,6 +149,11 @@ export function TokenTopHolders({ tokenId }: Props) {
                                                         {truncateAddress(`0x${h.address}`, 6)}
                                                     </Typography>
                                                 </Tooltip>
+                                                <CopyButton
+                                                    value={`0x${h.address}`}
+                                                    title="Copy address"
+                                                    size={14}
+                                                />
                                                 <IconButton
                                                     size="small"
                                                     href={explorerUrl}

--- a/src/components/transactions/transaction-view.tsx
+++ b/src/components/transactions/transaction-view.tsx
@@ -6,7 +6,17 @@ import {
     TimelineItem,
     TimelineSeparator,
 } from '@mui/lab'
-import { Box, Card, CardHeader, Divider, Grid, Link, Stack, Typography } from '@mui/material'
+import {
+    Box,
+    Button,
+    Card,
+    CardHeader,
+    Divider,
+    Grid,
+    Link,
+    Stack,
+    Typography,
+} from '@mui/material'
 import { formatDistanceToNow } from 'date-fns'
 import { TransactionDetailSkeleton } from 'src/components/skeletons'
 import { formatExplorerUrl, truncateAddress } from 'src/config/helper'
@@ -18,6 +28,8 @@ import { fDateTime } from 'src/utils/format-time'
 import { buildProfileQuery } from 'src/utils/helper'
 import { getTokensList, TransactionHistoryType, TransactionType } from 'src/utils/types'
 import useSWR from 'swr'
+import { paths } from 'src/routes/paths'
+import { CopyButton } from '../copy-button'
 import { Iconify } from '../iconify'
 
 export function TransactionView({ tx }: { tx: string }) {
@@ -37,14 +49,32 @@ export function TransactionView({ tx }: { tx: string }) {
         return (
             <Box
                 sx={{
-                    alignContent: 'center',
-                    alignItems: 'center',
                     display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
                     flex: 1,
-                    alignSelf: 'center',
+                    gap: 2,
+                    py: 8,
+                    textAlign: 'center',
                 }}
             >
-                <Typography variant={'h4'}>Could not find the transaction</Typography>
+                <Iconify icon="eva:search-outline" width={64} sx={{ color: 'text.disabled' }} />
+                <Typography variant="h4">Transaction not found</Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 420 }}>
+                    We couldn&apos;t find a bridge transaction with hash{' '}
+                    <Box component="span" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                        {truncateAddress(tx, 8)}
+                    </Box>
+                    . Double-check the hash or try switching the network.
+                </Typography>
+                <Button
+                    variant="contained"
+                    startIcon={<Iconify icon="eva:arrow-back-outline" />}
+                    onClick={() => router.push(paths.transactions.root)}
+                >
+                    Back to transactions
+                </Button>
             </Box>
         )
     }
@@ -134,7 +164,8 @@ export function TransactionView({ tx }: { tx: string }) {
                                                     boxShadow: 5,
                                                     transition: 'box-shadow 0.3s ease-in-out',
                                                     '&:hover': { boxShadow: 10 },
-                                                    minWidth: 500,
+                                                    width: '100%',
+                                                    minWidth: { xs: 0, md: 500 },
                                                     mx: 'auto', // centers the card horizontally
                                                 }}
                                             >
@@ -148,7 +179,7 @@ export function TransactionView({ tx }: { tx: string }) {
                                                 </Typography>
                                                 <Grid container spacing={2}>
                                                     {/* Left Column */}
-                                                    <Grid item xs={6}>
+                                                    <Grid item xs={12} sm={6}>
                                                         <Stack spacing={1}>
                                                             <Stack
                                                                 direction="row"
@@ -223,6 +254,11 @@ export function TransactionView({ tx }: { tx: string }) {
                                                                 >
                                                                     {truncateAddress(item.tx_hash)}
                                                                 </Link>
+                                                                <CopyButton
+                                                                    value={item.tx_hash}
+                                                                    title="Copy transaction hash"
+                                                                    size={14}
+                                                                />
                                                             </Stack>
 
                                                             <Stack
@@ -259,7 +295,7 @@ export function TransactionView({ tx }: { tx: string }) {
                                                         </Stack>
                                                     </Grid>
                                                     {/* Right Column */}
-                                                    <Grid item xs={6}>
+                                                    <Grid item xs={12} sm={6}>
                                                         <Stack spacing={1}>
                                                             <Stack
                                                                 direction="row"
@@ -291,6 +327,11 @@ export function TransactionView({ tx }: { tx: string }) {
                                                                         item.txn_sender,
                                                                     )}
                                                                 </Link>
+                                                                <CopyButton
+                                                                    value={item.txn_sender}
+                                                                    title="Copy sender address"
+                                                                    size={14}
+                                                                />
                                                             </Stack>
 
                                                             <Stack
@@ -419,7 +460,12 @@ function TransactionSummary({ tx, network }: { tx: TransactionType; network: NET
                             <Typography variant="caption" fontWeight="bold">
                                 Sender:
                             </Typography>
-                            <Box sx={{ display: 'flex' }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                                <CopyButton
+                                    value={tx.sender_address}
+                                    title="Copy sender address"
+                                    size={14}
+                                />
                                 <Link
                                     href={formatExplorerUrl({
                                         network,
@@ -453,7 +499,12 @@ function TransactionSummary({ tx, network }: { tx: TransactionType; network: NET
                             <Typography variant="caption" fontWeight="bold">
                                 Recipient:
                             </Typography>
-                            <Box sx={{ display: 'flex' }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                                <CopyButton
+                                    value={tx.recipient_address}
+                                    title="Copy recipient address"
+                                    size={14}
+                                />
                                 <Link
                                     href={formatExplorerUrl({
                                         network,
@@ -510,6 +561,11 @@ function TransactionSummary({ tx, network }: { tx: TransactionType; network: NET
                             <Typography variant="caption" fontWeight="bold">
                                 Tx:
                             </Typography>
+                            <CopyButton
+                                value={tx.tx_hash}
+                                title="Copy transaction hash"
+                                size={14}
+                            />
                             <Link
                                 href={formatExplorerUrl({
                                     network,

--- a/src/components/transactions/transactions-table.tsx
+++ b/src/components/transactions/transactions-table.tsx
@@ -11,7 +11,6 @@ import {
     TableCell,
     TableRow,
     TextField,
-    Tooltip,
     Typography,
 } from '@mui/material'
 import { formatDistanceToNow } from 'date-fns'
@@ -31,8 +30,8 @@ import { InputAdornment } from '@mui/material'
 import { MultiAddressAutocomplete } from './multi-address'
 import { useDebounce } from 'use-debounce'
 import CloseIcon from '@mui/icons-material/Close'
-import ContentCopyOutlinedIcon from '@mui/icons-material/ContentCopyOutlined'
 import { downloadCsv } from 'src/utils/csv'
+import { CopyButton } from '../copy-button'
 
 export function TransactionsTable({
     ethAddress,
@@ -447,14 +446,7 @@ const ActivitiesRow: React.FC<{
             {/* Sender with Improved Visibility */}
             <TableCell sx={{ paddingY: { xs: 0, sm: 2 } }}>
                 <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                    <Tooltip title="Copy sender address">
-                        <IconButton
-                            size="small"
-                            onClick={() => navigator.clipboard.writeText(row.sender_address)}
-                        >
-                            <ContentCopyOutlinedIcon fontSize="small" sx={{ fontSize: 16 }} />
-                        </IconButton>
-                    </Tooltip>
+                    <CopyButton value={row.sender_address} title="Copy sender address" />
                     <Link
                         href={formatExplorerUrl({
                             network,
@@ -486,14 +478,7 @@ const ActivitiesRow: React.FC<{
             {/* Recipient with Improved Visibility */}
             <TableCell>
                 <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                    <Tooltip title="Copy recipient address">
-                        <IconButton
-                            size="small"
-                            onClick={() => navigator.clipboard.writeText(row.recipient_address)}
-                        >
-                            <ContentCopyOutlinedIcon fontSize="small" sx={{ fontSize: 16 }} />
-                        </IconButton>
-                    </Tooltip>
+                    <CopyButton value={row.recipient_address} title="Copy recipient address" />
                     <Link
                         href={formatExplorerUrl({
                             network,
@@ -566,14 +551,7 @@ const ActivitiesRow: React.FC<{
             {/* Transaction Link */}
             <TableCell>
                 <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                    <Tooltip title="Copy transaction hash">
-                        <IconButton
-                            size="small"
-                            onClick={() => navigator.clipboard.writeText(row.tx_hash)}
-                        >
-                            <ContentCopyOutlinedIcon fontSize="small" sx={{ fontSize: 16 }} />
-                        </IconButton>
-                    </Tooltip>
+                    <CopyButton value={row.tx_hash} title="Copy transaction hash" />
                     <Link
                         href={formatExplorerUrl({
                             network,

--- a/src/layouts/components/global-search.tsx
+++ b/src/layouts/components/global-search.tsx
@@ -1,0 +1,254 @@
+'use client'
+
+import {
+    Box,
+    Dialog,
+    IconButton,
+    InputAdornment,
+    List,
+    ListItemButton,
+    ListItemIcon,
+    ListItemText,
+    TextField,
+    Tooltip,
+    Typography,
+} from '@mui/material'
+import { useTheme, alpha } from '@mui/material/styles'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Iconify } from 'src/components/iconify'
+import { truncateAddress } from 'src/config/helper'
+import { useRouter } from 'src/routes/hooks'
+import { paths } from 'src/routes/paths'
+
+// ----------------------------------------------------------------------
+
+const ETH_ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/
+const HEX_64_REGEX = /^(0x)?[0-9a-fA-F]{64}$/
+const SUI_DIGEST_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,50}$/
+
+type SearchResult = {
+    key: string
+    label: string
+    description: string
+    icon: string
+    href: string
+}
+
+/**
+ * Detects what the user pasted (ETH address, SUI address, transaction hash or
+ * SUI digest) and returns the matching navigation targets. A 0x + 64 hex chars
+ * value is ambiguous (ETH tx hash or SUI address), so both options are offered.
+ */
+export function detectSearchResults(rawQuery: string): SearchResult[] {
+    const query = rawQuery.trim()
+
+    if (!query) {
+        return []
+    }
+
+    const results: SearchResult[] = []
+
+    if (ETH_ADDRESS_REGEX.test(query)) {
+        results.push({
+            key: 'eth-profile',
+            label: `Ethereum address ${truncateAddress(query, 6)}`,
+            description: 'View bridge profile and transaction history',
+            icon: 'eva:person-outline',
+            href: `${paths.profile.root}?ethAddress=${query}`,
+        })
+        return results
+    }
+
+    if (HEX_64_REGEX.test(query)) {
+        const withPrefix = query.startsWith('0x') ? query : `0x${query}`
+        results.push({
+            key: 'tx',
+            label: `Transaction ${truncateAddress(withPrefix, 6)}`,
+            description: 'View bridge transaction details and timeline',
+            icon: 'mdi:fingerprint',
+            href: `${paths.transactions.root}/${withPrefix}`,
+        })
+        results.push({
+            key: 'sui-profile',
+            label: `SUI address ${truncateAddress(withPrefix, 6)}`,
+            description: 'View bridge profile and transaction history',
+            icon: 'eva:person-outline',
+            href: `${paths.profile.root}?suiAddress=${withPrefix}`,
+        })
+        return results
+    }
+
+    if (SUI_DIGEST_REGEX.test(query)) {
+        results.push({
+            key: 'sui-tx',
+            label: `SUI transaction ${truncateAddress(query, 6)}`,
+            description: 'View bridge transaction details and timeline',
+            icon: 'mdi:fingerprint',
+            href: `${paths.transactions.root}/${query}`,
+        })
+        return results
+    }
+
+    return results
+}
+
+// ----------------------------------------------------------------------
+
+export function GlobalSearch() {
+    const theme = useTheme()
+    const router = useRouter()
+    const [open, setOpen] = useState(false)
+    const [query, setQuery] = useState('')
+    const inputRef = useRef<HTMLInputElement>(null)
+
+    const focusInput = () => {
+        // Focus and select any leftover text so a new paste replaces it
+        inputRef.current?.focus()
+        inputRef.current?.select()
+    }
+
+    const results = useMemo(() => detectSearchResults(query), [query])
+    const showNoMatch = query.trim().length > 0 && results.length === 0
+
+    // Open with Cmd+K / Ctrl+K
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+                event.preventDefault()
+                setOpen(prev => {
+                    if (prev) {
+                        // Already open — just put the caret back in the input
+                        focusInput()
+                        return prev
+                    }
+                    return true
+                })
+            }
+        }
+        window.addEventListener('keydown', handleKeyDown)
+        return () => window.removeEventListener('keydown', handleKeyDown)
+    }, [])
+
+    const handleClose = () => {
+        setOpen(false)
+        setQuery('')
+    }
+
+    const handleNavigate = (href: string) => {
+        handleClose()
+        router.push(href)
+    }
+
+    const handleKeyDownInput = (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter' && results.length > 0) {
+            handleNavigate(results[0].href)
+        }
+    }
+
+    return (
+        <>
+            <Tooltip title="Search tx hash or address (⌘K)">
+                <IconButton onClick={() => setOpen(true)} aria-label="Search">
+                    <Iconify icon="eva:search-fill" width={22} />
+                </IconButton>
+            </Tooltip>
+
+            <Dialog
+                open={open}
+                onClose={handleClose}
+                fullWidth
+                maxWidth="sm"
+                sx={{ '& .MuiDialog-container': { alignItems: 'center' } }}
+                PaperProps={{ sx: { borderRadius: 2 } }}
+                slotProps={{
+                    backdrop: {
+                        sx: { backgroundColor: alpha(theme.palette.common.black, 0.8) },
+                    },
+                }}
+                TransitionProps={{ onEntered: focusInput }}
+            >
+                <Box sx={{ p: 2 }}>
+                    <TextField
+                        autoFocus
+                        inputRef={inputRef}
+                        fullWidth
+                        placeholder="Paste a transaction hash or address…"
+                        value={query}
+                        onChange={event => setQuery(event.target.value)}
+                        onKeyDown={handleKeyDownInput}
+                        InputProps={{
+                            startAdornment: (
+                                <InputAdornment position="start">
+                                    <Iconify
+                                        icon="eva:search-fill"
+                                        width={20}
+                                        sx={{ color: 'text.disabled' }}
+                                    />
+                                </InputAdornment>
+                            ),
+                            endAdornment: query ? (
+                                <InputAdornment position="end">
+                                    <IconButton size="small" onClick={() => setQuery('')}>
+                                        <Iconify icon="eva:close-fill" width={18} />
+                                    </IconButton>
+                                </InputAdornment>
+                            ) : undefined,
+                        }}
+                    />
+
+                    {results.length > 0 && (
+                        <List sx={{ mt: 1, pb: 0 }}>
+                            {results.map(result => (
+                                <ListItemButton
+                                    key={result.key}
+                                    onClick={() => handleNavigate(result.href)}
+                                    sx={{
+                                        borderRadius: 1,
+                                        '&:hover': {
+                                            bgcolor: alpha(theme.palette.primary.main, 0.08),
+                                        },
+                                    }}
+                                >
+                                    <ListItemIcon sx={{ minWidth: 36 }}>
+                                        <Iconify icon={result.icon} width={20} />
+                                    </ListItemIcon>
+                                    <ListItemText
+                                        primary={result.label}
+                                        secondary={result.description}
+                                        primaryTypographyProps={{
+                                            variant: 'body2',
+                                            fontWeight: 'bold',
+                                        }}
+                                        secondaryTypographyProps={{ variant: 'caption' }}
+                                    />
+                                    <Iconify
+                                        icon="eva:arrow-ios-forward-fill"
+                                        width={16}
+                                        sx={{ color: 'text.disabled' }}
+                                    />
+                                </ListItemButton>
+                            ))}
+                        </List>
+                    )}
+
+                    {showNoMatch && (
+                        <Box sx={{ py: 3, textAlign: 'center' }}>
+                            <Typography variant="body2" color="text.secondary">
+                                No match — paste a full transaction hash, SUI or Ethereum address
+                            </Typography>
+                        </Box>
+                    )}
+
+                    {!query && (
+                        <Box sx={{ pt: 1.5, px: 0.5 }}>
+                            <Typography variant="caption" color="text.disabled">
+                                Search a bridge transaction by hash, or look up a SUI / Ethereum
+                                address profile
+                            </Typography>
+                        </Box>
+                    )}
+                </Box>
+            </Dialog>
+        </>
+    )
+}

--- a/src/layouts/dashboard/layout.tsx
+++ b/src/layouts/dashboard/layout.tsx
@@ -9,6 +9,7 @@ import { Box, AppBar, Toolbar, Container, useMediaQuery } from '@mui/material'
 import { Logo } from 'src/components/logo'
 import { NetworkPopover } from '../components/network-popover'
 import { FilterPopover } from '../components/filter-popover'
+import { GlobalSearch } from '../components/global-search'
 import { NavTabs, MobileNavToggle, MobileNavMenu } from '../components/nav-tabs'
 import { layoutClasses } from '../classes'
 import { varAlpha } from 'src/theme/styles'
@@ -99,6 +100,7 @@ export function DashboardLayout({ sx, children, disableTimelines }: DashboardLay
                                 justifyContent: 'flex-end',
                             }}
                         >
+                            <GlobalSearch />
                             {!disableTimelines && <FilterPopover />}
                             <NetworkPopover />
                         </Box>


### PR DESCRIPTION
## Summary

### 🔍 Global Search
- New search button in the header (also opens with **⌘K / Ctrl+K**, auto-focuses the input)
- Smart detection of pasted values:
  - `0x` + 40 hex → Ethereum address → profile page
  - `0x` + 64 hex → ambiguous, offers both **Transaction** and **SUI address** targets
  - Base58 digest → SUI transaction → detail page
- Enter navigates to the first result; friendly no-match and hint states
- Vertically centered dialog with a darkened backdrop for focus

### 📋 Copy & transaction detail polish
- New reusable `CopyButton` component with "Copied!" checkmark feedback — now the **single copy implementation used app-wide**:
  - Transactions table: the 3 silent copy buttons (sender / recipient / tx hash) now confirm the copy
  - Transaction detail: added copy buttons for sender, recipient and tx hash in summary card + timeline entries
  - Leaderboard `AddressCell`: replaced its own inline copy implementation with the shared component (-32 lines)
  - Token detail Top Senders: added the previously missing copy button next to each sender address
- Transaction detail page:
  - Fixed mobile overflow (hardcoded `minWidth: 500` → responsive) and stacked timeline columns on small screens
  - Replaced bare "Could not find the transaction" text with a proper not-found state (icon, searched hash, network hint, "Back to transactions" button)

## Test plan
- [x] `yarn ts` typecheck passes
- [x] Verified in browser: ⌘K opens/focuses search, all 3 input formats detected, Enter navigates
- [x] Verified not-found state renders with back navigation
- [x] Copy buttons verified with live data on /transactions, /transactions/[tx], /leaderboard and /tokens/[id] — all show green "Copied!" feedback
- [x] Leaderboard row-click navigation still works (copy click doesn't propagate)