### PR TITLE
Shareable URLs for all filters + profile validation & share

### DIFF
--- a/src/app/(dashboard)/flows/page.tsx
+++ b/src/app/(dashboard)/flows/page.tsx
@@ -27,7 +27,7 @@ import { DashboardContent } from 'src/layouts/dashboard'
 import { useGlobalContext } from 'src/provider/global-provider'
 import { endpoints, fetcher } from 'src/utils/axios'
 import { FlowRow, getTokensList } from 'src/utils/types'
-import { useState } from 'react'
+import { useQueryParamState } from 'src/hooks/use-query-param-state'
 
 const CHAIN_COLORS: Record<string, string> = {
     SUI: '#4DA2FF',
@@ -55,8 +55,15 @@ export default function FlowsPage() {
     const { timePeriod, selectedTokens } = useGlobalContext()
     const networkConfig = getNetworkConfig({ network })
 
-    const [unit, setUnit] = useState<'usd' | 'count'>('usd')
-    const [mode, setMode] = useState<'gross' | 'net'>('gross')
+    // Shareable toggles: mirrored into the URL query string
+    const [unit, setUnit] = useQueryParamState<'usd' | 'count'>('unit', {
+        defaultValue: 'usd',
+        deserialize: raw => (raw === 'count' ? raw : null),
+    })
+    const [mode, setMode] = useQueryParamState<'gross' | 'net'>('mode', {
+        defaultValue: 'gross',
+        deserialize: raw => (raw === 'net' ? raw : null),
+    })
 
     const { data, isLoading } = useSWR<FlowRow[]>(
         `${endpoints.flows}?network=${network}&period=${encodeURIComponent(timePeriod)}`,

--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -12,7 +12,7 @@ import {
     Typography,
 } from '@mui/material'
 import { useSearchParams } from 'next/navigation'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useDebounce } from 'use-debounce'
 import { Iconify } from 'src/components/iconify'
 import { writeQueryParams } from 'src/hooks/use-query-param-state'
@@ -102,12 +102,17 @@ const ETH_LOGO_PATH = '/assets/icons/brands/eth.svg'
 
 function ShareProfileButton() {
     const [copied, setCopied] = useState(false)
+    const timeoutRef = useRef<ReturnType<typeof setTimeout>>()
+
+    // Clear pending feedback timeout on unmount
+    useEffect(() => () => clearTimeout(timeoutRef.current), [])
 
     const handleShare = async () => {
         try {
             await navigator.clipboard.writeText(window.location.href)
             setCopied(true)
-            setTimeout(() => setCopied(false), 2000)
+            clearTimeout(timeoutRef.current)
+            timeoutRef.current = setTimeout(() => setCopied(false), 2000)
         } catch (error) {
             console.error('Failed to copy profile link:', error)
         }

--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -12,8 +12,11 @@ import {
     Typography,
 } from '@mui/material'
 import { useSearchParams } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { useDebounce } from 'use-debounce'
 import { Iconify } from 'src/components/iconify'
+import { writeQueryParams } from 'src/hooks/use-query-param-state'
+import { isValidEthAddress, isValidSuiAddress } from 'src/utils/address-validation'
 import { TransactionsTable } from 'src/components/transactions/transactions-table'
 import UserStatsWidgets from 'src/components/widgets/user-stats-widgets'
 import { DashboardContent } from 'src/layouts/dashboard'
@@ -97,11 +100,64 @@ function WalletActionButton({
 const SUI_LOGO_PATH = '/assets/icons/brands/sui.svg'
 const ETH_LOGO_PATH = '/assets/icons/brands/eth.svg'
 
+function ShareProfileButton() {
+    const [copied, setCopied] = useState(false)
+
+    const handleShare = async () => {
+        try {
+            await navigator.clipboard.writeText(window.location.href)
+            setCopied(true)
+            setTimeout(() => setCopied(false), 2000)
+        } catch (error) {
+            console.error('Failed to copy profile link:', error)
+        }
+    }
+
+    return (
+        <Button
+            variant="outlined"
+            size="small"
+            color={copied ? 'success' : 'primary'}
+            onClick={handleShare}
+            startIcon={
+                <Iconify icon={copied ? 'eva:checkmark-fill' : 'solar:share-bold'} width={18} />
+            }
+            sx={{ borderRadius: 2, textTransform: 'none', fontWeight: 600 }}
+        >
+            {copied ? 'Link copied!' : 'Share profile'}
+        </Button>
+    )
+}
+
 function ProfileContent() {
     const searchParams = useSearchParams()
 
     const [suiAddress, setSuiAddress] = useState(searchParams?.get('suiAddress') || '')
     const [ethAddress, setEthAddress] = useState(searchParams?.get('ethAddress') || '')
+
+    // Validation (only flag as error once the value is complete enough to judge)
+    const suiValid = !suiAddress || isValidSuiAddress(suiAddress)
+    const ethValid = !ethAddress || isValidEthAddress(ethAddress)
+
+    // Only query/share valid addresses — avoids silent empty results on typos
+    const activeSuiAddress = useMemo(
+        () => (suiAddress && isValidSuiAddress(suiAddress) ? suiAddress : ''),
+        [suiAddress],
+    )
+    const activeEthAddress = useMemo(
+        () => (ethAddress && isValidEthAddress(ethAddress) ? ethAddress : ''),
+        [ethAddress],
+    )
+
+    // Keep the URL in sync so any profile view is a shareable link
+    const [debouncedSui] = useDebounce(activeSuiAddress, 400)
+    const [debouncedEth] = useDebounce(activeEthAddress, 400)
+    useEffect(() => {
+        writeQueryParams({
+            suiAddress: debouncedSui || null,
+            ethAddress: debouncedEth || null,
+        })
+    }, [debouncedSui, debouncedEth])
 
     const handlePasteSui = async () => {
         try {
@@ -158,7 +214,11 @@ function ProfileContent() {
                             variant="outlined"
                             value={suiAddress}
                             placeholder="6a44..."
-                            onChange={e => setSuiAddress(e.target.value)}
+                            error={!suiValid}
+                            helperText={
+                                !suiValid ? 'Invalid SUI address — expected 64 hex characters' : ' '
+                            }
+                            onChange={e => setSuiAddress(e.target.value.trim())}
                             InputProps={{
                                 startAdornment: (
                                     <InputAdornment position="start">
@@ -241,7 +301,13 @@ function ProfileContent() {
                             variant="outlined"
                             placeholder="0x..."
                             value={ethAddress}
-                            onChange={e => setEthAddress(e.target.value)}
+                            error={!ethValid}
+                            helperText={
+                                !ethValid
+                                    ? 'Invalid Ethereum address — expected 0x + 40 hex characters'
+                                    : ' '
+                            }
+                            onChange={e => setEthAddress(e.target.value.trim())}
                             InputProps={{
                                 startAdornment: (
                                     <InputAdornment position="start">
@@ -307,10 +373,16 @@ function ProfileContent() {
                     </Stack>
                 </Grid>
             </Grid>
-            {suiAddress || ethAddress ? (
+            {activeSuiAddress || activeEthAddress ? (
                 <>
-                    <UserStatsWidgets suiAddress={suiAddress} ethAddress={ethAddress} />
-                    <TransactionsTable suiAddress={suiAddress} ethAddress={ethAddress} />
+                    <Stack direction="row" justifyContent="flex-end" sx={{ mb: 2 }}>
+                        <ShareProfileButton />
+                    </Stack>
+                    <UserStatsWidgets suiAddress={activeSuiAddress} ethAddress={activeEthAddress} />
+                    <TransactionsTable
+                        suiAddress={activeSuiAddress}
+                        ethAddress={activeEthAddress}
+                    />
                 </>
             ) : (
                 <Box

--- a/src/app/(dashboard)/transactions/page.tsx
+++ b/src/app/(dashboard)/transactions/page.tsx
@@ -7,7 +7,7 @@ export default function Page() {
     return (
         <DashboardContent maxWidth="xl">
             <PageTitle title="Bridge Transactions" />
-            <TransactionsTable />
+            <TransactionsTable syncFiltersToUrl />
         </DashboardContent>
     )
 }

--- a/src/components/copy-button/copy-button.tsx
+++ b/src/components/copy-button/copy-button.tsx
@@ -1,5 +1,5 @@
 import { IconButton, Tooltip } from '@mui/material'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Iconify } from '../iconify'
 
 // ----------------------------------------------------------------------
@@ -20,6 +20,9 @@ type CopyButtonProps = {
 export function CopyButton({ value, title = 'Copy', size = 16 }: CopyButtonProps) {
     const [copied, setCopied] = useState(false)
     const timeoutRef = useRef<ReturnType<typeof setTimeout>>()
+
+    // Clear pending feedback timeout on unmount
+    useEffect(() => () => clearTimeout(timeoutRef.current), [])
 
     const handleCopy = async (event: React.MouseEvent) => {
         event.stopPropagation()

--- a/src/components/leaderboard/leaderboard-table.tsx
+++ b/src/components/leaderboard/leaderboard-table.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import {
     Box,
     Card,
@@ -24,6 +24,7 @@ import { useRouter } from 'next/navigation'
 import useSWR from 'swr'
 import { endpoints, fetcher } from 'src/utils/axios'
 import { getNetwork } from 'src/hooks/get-network-storage'
+import { readQueryParam, useQueryParamState } from 'src/hooks/use-query-param-state'
 import { useGlobalContext } from 'src/provider/global-provider'
 import { fCurrency, fNumber } from 'src/utils/format-number'
 import { fDate } from 'src/utils/format-time'
@@ -49,14 +50,42 @@ export function LeaderboardTable() {
     const network = getNetwork()
     const { timePeriod } = useGlobalContext()
 
-    const [page, setPage] = useState(0)
-    const [addressType, setAddressType] = useState<AddressTypeFilter>('all')
-    const [sortBy, setSortBy] = useState<SortByOption>('volume')
+    // Shareable state: mirrored into the URL query string
+    const [page, setPage] = useQueryParamState<number>('page', {
+        defaultValue: 0,
+        deserialize: raw => {
+            const parsed = Number(raw)
+            return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+        },
+    })
+    const [addressType, setAddressType] = useQueryParamState<AddressTypeFilter>('chain', {
+        defaultValue: 'all',
+        deserialize: raw => (raw === 'sui' || raw === 'eth' ? raw : null),
+    })
+    const [sortBy, setSortBy] = useQueryParamState<SortByOption>('sortBy', {
+        defaultValue: 'volume',
+        deserialize: raw => (raw === 'count' ? raw : null),
+    })
 
-    // Reset page when filters change
+    // Reset page when the global time period actually changes. The provider
+    // hydrates the period from the URL *after* mount — that first transition
+    // (landing exactly on the URL's period value) is hydration, not a user
+    // change, so it must not wipe a shared ?page=.
+    const prevTimePeriod = useRef<string>(timePeriod)
+    const pendingUrlPeriod = useRef<string | null>(readQueryParam('period'))
     useEffect(() => {
+        if (prevTimePeriod.current === timePeriod) {
+            return
+        }
+        prevTimePeriod.current = timePeriod
+        if (pendingUrlPeriod.current === timePeriod) {
+            pendingUrlPeriod.current = null
+            return
+        }
+        pendingUrlPeriod.current = null
         setPage(0)
-    }, [addressType, sortBy, timePeriod])
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [timePeriod])
 
     // Build query string
     const queryString = useMemo(() => {
@@ -105,12 +134,14 @@ export function LeaderboardTable() {
     const handleAddressTypeChange = (_: React.SyntheticEvent, newValue: AddressTypeFilter) => {
         if (newValue !== null) {
             setAddressType(newValue)
+            setPage(0)
         }
     }
 
     const handleSortChange = (_: React.MouseEvent<HTMLElement>, newSort: SortByOption) => {
         if (newSort !== null) {
             setSortBy(newSort)
+            setPage(0)
         }
     }
 

--- a/src/components/transactions/transactions-table.tsx
+++ b/src/components/transactions/transactions-table.tsx
@@ -14,7 +14,7 @@ import {
     Typography,
 } from '@mui/material'
 import { formatDistanceToNow } from 'date-fns'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { formatExplorerUrl, truncateAddress } from 'src/config/helper'
 import { getNetwork, NETWORK } from 'src/hooks/get-network-storage'
 import { useRouter } from 'src/routes/hooks'
@@ -31,6 +31,7 @@ import { MultiAddressAutocomplete } from './multi-address'
 import { useDebounce } from 'use-debounce'
 import CloseIcon from '@mui/icons-material/Close'
 import { downloadCsv } from 'src/utils/csv'
+import { readQueryParam, writeQueryParams } from 'src/hooks/use-query-param-state'
 import { CopyButton } from '../copy-button'
 
 export function TransactionsTable({
@@ -42,6 +43,7 @@ export function TransactionsTable({
     minHeight = 800,
     autoRefreshIntervalMs = 30000,
     autoRefreshEnabledDefault = true,
+    syncFiltersToUrl = false,
 }: {
     ethAddress?: string
     suiAddress?: string
@@ -51,29 +53,115 @@ export function TransactionsTable({
     minHeight?: number
     autoRefreshIntervalMs?: number
     autoRefreshEnabledDefault?: boolean
+    /** Mirror filters into the URL query string so the view is shareable */
+    syncFiltersToUrl?: boolean
 }) {
     const network = getNetwork()
     const router = useRouter()
-    const [page, setPage] = useState(0)
     const [totalItems, setTotalItems] = useState(0)
-    const [showFilters, setShowFilters] = useState(false)
     const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(autoRefreshEnabledDefault)
     const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null)
-    const [filters, setFilters] = useState<{
-        flow: 'all' | 'inflow' | 'outflow'
+
+    type Flow = 'all' | 'inflow' | 'outflow'
+    type Filters = {
+        flow: Flow
         senders: string[]
         recipients: string[]
         amountFrom: string
         amountTo: string
-    }>({
+    }
+
+    const [filters, setFilters] = useState<Filters>({
         flow: 'all',
         senders: [],
         recipients: [],
         amountFrom: '',
         amountTo: '',
     })
+    const [page, setPage] = useState(0)
+    const [showFilters, setShowFilters] = useState(false)
     const [amountPreset, setAmountPreset] = useState<'any' | 'low' | 'medium' | 'large'>('any')
     const pageSize = limit
+
+    const filtersKey = (f: Filters) =>
+        [f.flow, f.senders.join(','), f.recipients.join(','), f.amountFrom, f.amountTo].join('|')
+
+    // Hydrate filters/page from the URL after mount (shareable links).
+    // `urlHydrated` is state (not a ref) so the write/reset effects below only
+    // activate once the hydrated values have actually been committed —
+    // otherwise they'd run with stale defaults and wipe the shared URL.
+    const [urlHydrated, setUrlHydrated] = useState(!syncFiltersToUrl)
+    const prevFiltersKey = useRef<string>(filtersKey(filters))
+    useEffect(() => {
+        if (!syncFiltersToUrl) {
+            return
+        }
+        const flowParam = readQueryParam('flow')
+        const urlFilters: Filters = {
+            flow: flowParam === 'inflow' || flowParam === 'outflow' ? (flowParam as Flow) : 'all',
+            senders: (readQueryParam('senders') || '').split(',').filter(Boolean),
+            recipients: (readQueryParam('recipients') || '').split(',').filter(Boolean),
+            amountFrom: readQueryParam('amountFrom') || '',
+            amountTo: readQueryParam('amountTo') || '',
+        }
+        const rawPage = Number(readQueryParam('page'))
+        const urlPage = Number.isInteger(rawPage) && rawPage > 0 ? rawPage : 0
+
+        const hasUrlFilters =
+            urlFilters.flow !== 'all' ||
+            urlFilters.senders.length > 0 ||
+            urlFilters.recipients.length > 0 ||
+            !!urlFilters.amountFrom ||
+            !!urlFilters.amountTo
+
+        if (hasUrlFilters) {
+            prevFiltersKey.current = filtersKey(urlFilters)
+            setFilters(urlFilters)
+            setShowFilters(true)
+        }
+        if (urlPage > 0) {
+            setPage(urlPage)
+        }
+        setUrlHydrated(true)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [syncFiltersToUrl])
+
+    // Mirror filters/page into the URL so the current view is shareable
+    useEffect(() => {
+        if (!syncFiltersToUrl || !urlHydrated) {
+            return
+        }
+        writeQueryParams({
+            flow: filters.flow === 'all' ? null : filters.flow,
+            senders: filters.senders.length ? filters.senders.join(',') : null,
+            recipients: filters.recipients.length ? filters.recipients.join(',') : null,
+            amountFrom: filters.amountFrom || null,
+            amountTo: filters.amountTo || null,
+            page: page > 0 ? String(page) : null,
+        })
+    }, [syncFiltersToUrl, urlHydrated, filters, page])
+
+    // Reset page when filters actually change (compare serialized values —
+    // StrictMode-safe, and URL hydration doesn't count as a change)
+    useEffect(() => {
+        if (!urlHydrated) {
+            return
+        }
+        const key = filtersKey(filters)
+        if (prevFiltersKey.current === key) {
+            return
+        }
+        prevFiltersKey.current = key
+        setPage(0)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+        urlHydrated,
+        filters.flow,
+        filters.senders,
+        filters.recipients,
+        filters.amountFrom,
+        filters.amountTo,
+    ])
 
     const [debouncedFilters] = useDebounce(filters, 500)
     // Fetch paginated data

--- a/src/components/transactions/transactions-table.tsx
+++ b/src/components/transactions/transactions-table.tsx
@@ -96,13 +96,23 @@ export function TransactionsTable({
         if (!syncFiltersToUrl) {
             return
         }
+        // Only accept finite, non-negative numbers for amounts — a malformed
+        // shared link (?amountFrom=abc) would otherwise push NaN into the API
+        const readAmountParam = (key: string): string => {
+            const raw = readQueryParam(key)
+            if (!raw) {
+                return ''
+            }
+            const parsed = Number(raw)
+            return Number.isFinite(parsed) && parsed >= 0 ? raw : ''
+        }
         const flowParam = readQueryParam('flow')
         const urlFilters: Filters = {
             flow: flowParam === 'inflow' || flowParam === 'outflow' ? (flowParam as Flow) : 'all',
             senders: (readQueryParam('senders') || '').split(',').filter(Boolean),
             recipients: (readQueryParam('recipients') || '').split(',').filter(Boolean),
-            amountFrom: readQueryParam('amountFrom') || '',
-            amountTo: readQueryParam('amountTo') || '',
+            amountFrom: readAmountParam('amountFrom'),
+            amountTo: readAmountParam('amountTo'),
         }
         const rawPage = Number(readQueryParam('page'))
         const urlPage = Number.isInteger(rawPage) && rawPage > 0 ? rawPage : 0

--- a/src/hooks/use-query-param-state.ts
+++ b/src/hooks/use-query-param-state.ts
@@ -1,0 +1,104 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+// ----------------------------------------------------------------------
+
+/**
+ * Read a query param from the current URL (client side only).
+ */
+export function readQueryParam(key: string): string | null {
+    if (typeof window === 'undefined') {
+        return null
+    }
+    return new URLSearchParams(window.location.search).get(key)
+}
+
+/**
+ * Write query params into the current URL without triggering a Next.js
+ * navigation (no re-render, no scroll reset). Passing `null`/`undefined`/''
+ * as a value removes the param, keeping shared URLs clean.
+ */
+export function writeQueryParams(params: Record<string, string | null | undefined>) {
+    if (typeof window === 'undefined') {
+        return
+    }
+    const searchParams = new URLSearchParams(window.location.search)
+
+    Object.entries(params).forEach(([key, value]) => {
+        if (value === null || value === undefined || value === '') {
+            searchParams.delete(key)
+        } else {
+            searchParams.set(key, value)
+        }
+    })
+
+    const query = searchParams.toString()
+    const newUrl = `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`
+    window.history.replaceState(window.history.state, '', newUrl)
+}
+
+// ----------------------------------------------------------------------
+
+type Options<T> = {
+    /** Serialized value equal to this is removed from the URL (keeps links clean) */
+    defaultValue: T
+    /** Convert the state value to its URL string representation */
+    serialize?: (value: T) => string
+    /** Convert the URL string back to a state value; return null to reject invalid input */
+    deserialize?: (raw: string) => T | null
+}
+
+/**
+ * `useState` that mirrors its value into a URL query param, making the view
+ * shareable. To stay SSR/hydration-safe, the first render always uses
+ * `defaultValue`; the URL value is applied in a mount effect. Updates rewrite
+ * the URL in place via `history.replaceState` — no navigation, no scroll jump.
+ */
+export function useQueryParamState<T>(
+    key: string,
+    { defaultValue, serialize, deserialize }: Options<T>,
+): [T, (value: T) => void] {
+    const serializeFn = serialize ?? ((value: T) => String(value))
+    const deserializeFn = deserialize ?? ((raw: string) => raw as unknown as T)
+
+    // Server render and first client render must match → start with default
+    const [value, setValue] = useState<T>(defaultValue)
+
+    // Keep latest fns without re-running effects/callbacks
+    const serializeRef = useRef(serializeFn)
+    serializeRef.current = serializeFn
+    const deserializeRef = useRef(deserializeFn)
+    deserializeRef.current = deserializeFn
+    const defaultSerializedRef = useRef(serializeFn(defaultValue))
+    defaultSerializedRef.current = serializeFn(defaultValue)
+
+    // After mount, hydrate state from the URL (shareable link support)
+    useEffect(() => {
+        const raw = readQueryParam(key)
+        if (raw === null) {
+            return
+        }
+        const parsed = deserializeRef.current(raw)
+        if (parsed === null) {
+            // Invalid param value — drop it from the URL
+            writeQueryParams({ [key]: null })
+            return
+        }
+        setValue(parsed)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [key])
+
+    const update = useCallback(
+        (newValue: T) => {
+            setValue(newValue)
+            const serialized = serializeRef.current(newValue)
+            writeQueryParams({
+                [key]: serialized === defaultSerializedRef.current ? null : serialized,
+            })
+        },
+        [key],
+    )
+
+    return [value, update]
+}

--- a/src/layouts/components/global-search.tsx
+++ b/src/layouts/components/global-search.tsx
@@ -19,12 +19,9 @@ import { Iconify } from 'src/components/iconify'
 import { truncateAddress } from 'src/config/helper'
 import { useRouter } from 'src/routes/hooks'
 import { paths } from 'src/routes/paths'
+import { ETH_ADDRESS_REGEX, HEX_64_REGEX, SUI_DIGEST_REGEX } from 'src/utils/address-validation'
 
 // ----------------------------------------------------------------------
-
-const ETH_ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/
-const HEX_64_REGEX = /^(0x)?[0-9a-fA-F]{64}$/
-const SUI_DIGEST_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,50}$/
 
 type SearchResult = {
     key: string

--- a/src/provider/global-provider.tsx
+++ b/src/provider/global-provider.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { createContext, ReactNode, useContext, useEffect, useState } from 'react'
-import { TimePeriod } from 'src/config/helper'
+import { TIME_PERIODS, TimePeriod } from 'src/config/helper'
+import { readQueryParam, writeQueryParams } from 'src/hooks/use-query-param-state'
 import { NETWORK } from 'src/hooks/get-network-storage'
 import { getDefaultConfig, RainbowKitProvider } from '@rainbow-me/rainbowkit'
 import { WagmiProvider } from 'wagmi'
@@ -47,24 +48,45 @@ export const GlobalProvider = ({ children }: { children: ReactNode }) => {
     const [timePeriod, setTimePeriodState] = useState<TimePeriod>('Last Month')
     const [selectedTokens, setSelectedTokensState] = useState<string[]>(['All'])
 
-    // Update local storage and state when timePeriod changes
+    // Update URL + local storage + state when timePeriod changes
     const setTimePeriod = (newTimePeriod: TimePeriod) => {
         setTimePeriodState(newTimePeriod)
         localStorage.setItem('timePeriod', newTimePeriod)
+        writeQueryParams({ period: newTimePeriod === 'Last Month' ? null : newTimePeriod })
     }
 
-    // Update local storage and state when selectedTokens changes
+    // Update URL + local storage + state when selectedTokens changes
     const setSelectedTokens = (newTokens: string[]) => {
         setSelectedTokensState(newTokens)
         localStorage.setItem('selectedTokens', JSON.stringify(newTokens))
+        const isDefault =
+            newTokens.length === 0 || (newTokens.length === 1 && newTokens[0] === 'All')
+        writeQueryParams({ tokens: isDefault ? null : newTokens.join(',') })
     }
 
     useEffect(() => {
-        // Load initial values from local storage when the component mounts
-        const tokens = localStorage.getItem('selectedTokens')
+        // Load initial values when the component mounts.
+        // Shareable URL params take precedence over local storage.
+        const urlPeriod = readQueryParam('period')
+        const urlTokens = readQueryParam('tokens')
+        const storedTokens = localStorage.getItem('selectedTokens')
 
-        setTimePeriodState((localStorage.getItem('timePeriod') || 'Last Month') as TimePeriod)
-        setSelectedTokensState(tokens ? JSON.parse(tokens) : ['All'])
+        if (urlPeriod && TIME_PERIODS.includes(urlPeriod as TimePeriod)) {
+            setTimePeriodState(urlPeriod as TimePeriod)
+            localStorage.setItem('timePeriod', urlPeriod)
+        } else {
+            setTimePeriodState((localStorage.getItem('timePeriod') || 'Last Month') as TimePeriod)
+        }
+
+        if (urlTokens) {
+            const tokens = urlTokens.split(',').filter(Boolean)
+            if (tokens.length > 0) {
+                setSelectedTokensState(tokens)
+                localStorage.setItem('selectedTokens', JSON.stringify(tokens))
+                return
+            }
+        }
+        setSelectedTokensState(storedTokens ? JSON.parse(storedTokens) : ['All'])
     }, [])
 
     useEffect(() => {

--- a/src/provider/global-provider.tsx
+++ b/src/provider/global-provider.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { createContext, ReactNode, useContext, useEffect, useState } from 'react'
+import { usePathname } from 'next/navigation'
+import { createContext, ReactNode, useContext, useEffect, useRef, useState } from 'react'
 import { TIME_PERIODS, TimePeriod } from 'src/config/helper'
 import { readQueryParam, writeQueryParams } from 'src/hooks/use-query-param-state'
 import { NETWORK } from 'src/hooks/get-network-storage'
@@ -42,52 +43,107 @@ const { networkConfig } = createNetworkConfig({
 })
 const queryClient = new QueryClient()
 
+const DEFAULT_PERIOD: TimePeriod = 'Last Month'
+const DEFAULT_TOKENS = ['All']
+
+const isDefaultTokens = (tokens: string[]) =>
+    tokens.length === 0 || (tokens.length === 1 && tokens[0] === 'All')
+
+/** Validate a raw period value (URL/localStorage) against the known list */
+const parsePeriod = (raw: string | null): TimePeriod | null =>
+    raw && TIME_PERIODS.includes(raw as TimePeriod) ? (raw as TimePeriod) : null
+
 export const GlobalProvider = ({ children }: { children: ReactNode }) => {
+    const pathname = usePathname()
     const [network, setNetworkState] = useState<NETWORK>(NETWORK.MAINNET)
     const [isMounted, setIsMounted] = useState(false)
-    const [timePeriod, setTimePeriodState] = useState<TimePeriod>('Last Month')
-    const [selectedTokens, setSelectedTokensState] = useState<string[]>(['All'])
+    const [timePeriod, setTimePeriodState] = useState<TimePeriod>(DEFAULT_PERIOD)
+    const [selectedTokens, setSelectedTokensState] = useState<string[]>(DEFAULT_TOKENS)
+    const isHydrated = useRef(false)
 
     // Update URL + local storage + state when timePeriod changes
     const setTimePeriod = (newTimePeriod: TimePeriod) => {
         setTimePeriodState(newTimePeriod)
         localStorage.setItem('timePeriod', newTimePeriod)
-        writeQueryParams({ period: newTimePeriod === 'Last Month' ? null : newTimePeriod })
+        writeQueryParams({ period: newTimePeriod === DEFAULT_PERIOD ? null : newTimePeriod })
     }
 
     // Update URL + local storage + state when selectedTokens changes
     const setSelectedTokens = (newTokens: string[]) => {
         setSelectedTokensState(newTokens)
         localStorage.setItem('selectedTokens', JSON.stringify(newTokens))
-        const isDefault =
-            newTokens.length === 0 || (newTokens.length === 1 && newTokens[0] === 'All')
-        writeQueryParams({ tokens: isDefault ? null : newTokens.join(',') })
+        writeQueryParams({ tokens: isDefaultTokens(newTokens) ? null : newTokens.join(',') })
     }
 
     useEffect(() => {
         // Load initial values when the component mounts.
-        // Shareable URL params take precedence over local storage.
-        const urlPeriod = readQueryParam('period')
-        const urlTokens = readQueryParam('tokens')
-        const storedTokens = localStorage.getItem('selectedTokens')
+        // Shareable URL params take precedence over local storage; invalid or
+        // default-valued params are removed to keep shared URLs clean.
+        const urlPeriodRaw = readQueryParam('period')
+        const urlPeriod = parsePeriod(urlPeriodRaw)
+        const urlTokensRaw = readQueryParam('tokens')
+        const urlTokens = urlTokensRaw ? urlTokensRaw.split(',').filter(Boolean) : []
 
-        if (urlPeriod && TIME_PERIODS.includes(urlPeriod as TimePeriod)) {
-            setTimePeriodState(urlPeriod as TimePeriod)
+        if (urlPeriod) {
+            setTimePeriodState(urlPeriod)
             localStorage.setItem('timePeriod', urlPeriod)
+            if (urlPeriod === DEFAULT_PERIOD) {
+                writeQueryParams({ period: null })
+            }
         } else {
-            setTimePeriodState((localStorage.getItem('timePeriod') || 'Last Month') as TimePeriod)
+            if (urlPeriodRaw !== null) {
+                // Present but invalid — drop it
+                writeQueryParams({ period: null })
+            }
+            // Validate localStorage too (may hold stale/renamed values)
+            setTimePeriodState(parsePeriod(localStorage.getItem('timePeriod')) ?? DEFAULT_PERIOD)
         }
 
-        if (urlTokens) {
-            const tokens = urlTokens.split(',').filter(Boolean)
-            if (tokens.length > 0) {
-                setSelectedTokensState(tokens)
-                localStorage.setItem('selectedTokens', JSON.stringify(tokens))
-                return
+        if (urlTokens.length > 0 && !isDefaultTokens(urlTokens)) {
+            setSelectedTokensState(urlTokens)
+            localStorage.setItem('selectedTokens', JSON.stringify(urlTokens))
+        } else {
+            if (urlTokensRaw !== null) {
+                // Present but empty/default — drop it
+                writeQueryParams({ tokens: null })
             }
+            const storedTokens = localStorage.getItem('selectedTokens')
+            setSelectedTokensState(storedTokens ? JSON.parse(storedTokens) : DEFAULT_TOKENS)
         }
-        setSelectedTokensState(storedTokens ? JSON.parse(storedTokens) : ['All'])
+
+        isHydrated.current = true
     }, [])
+
+    // On client-side navigation the new URL starts bare — re-serialize the
+    // active global filters into it so copying the address bar after
+    // navigating still reproduces the current view.
+    useEffect(() => {
+        if (!isHydrated.current) {
+            return
+        }
+        // If the destination URL itself carries filter params (e.g. a shared
+        // link opened via client navigation), let them win over current state.
+        const urlPeriod = parsePeriod(readQueryParam('period'))
+        const urlTokensRaw = readQueryParam('tokens')
+        const urlTokens = urlTokensRaw ? urlTokensRaw.split(',').filter(Boolean) : []
+
+        if (urlPeriod && urlPeriod !== timePeriod) {
+            setTimePeriodState(urlPeriod)
+            localStorage.setItem('timePeriod', urlPeriod)
+            return
+        }
+        if (urlTokens.length > 0 && urlTokens.join(',') !== selectedTokens.join(',')) {
+            setSelectedTokensState(urlTokens)
+            localStorage.setItem('selectedTokens', JSON.stringify(urlTokens))
+            return
+        }
+
+        writeQueryParams({
+            period: timePeriod === DEFAULT_PERIOD ? null : timePeriod,
+            tokens: isDefaultTokens(selectedTokens) ? null : selectedTokens.join(','),
+        })
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [pathname])
 
     useEffect(() => {
         // Set mounted to true once component is mounted

--- a/src/utils/address-validation.ts
+++ b/src/utils/address-validation.ts
@@ -1,0 +1,16 @@
+// ----------------------------------------------------------------------
+// Shared address / hash format validation for SUI and Ethereum values.
+
+export const ETH_ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/
+export const HEX_64_REGEX = /^(0x)?[0-9a-fA-F]{64}$/
+export const SUI_DIGEST_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,50}$/
+
+/** Ethereum account address: 0x + 40 hex chars */
+export function isValidEthAddress(value: string): boolean {
+    return ETH_ADDRESS_REGEX.test(value.trim())
+}
+
+/** SUI account address: 64 hex chars, 0x prefix optional */
+export function isValidSuiAddress(value: string): boolean {
+    return HEX_64_REGEX.test(value.trim())
+}


### PR DESCRIPTION
## Summary

### 🔗 Shareable URLs — every view is now a link
New `useQueryParamState` hook (`src/hooks/use-query-param-state.ts`) mirrors UI state into URL query params via `history.replaceState` — no navigation, no scroll jump, SSR/hydration-safe (first render uses defaults, URL hydrates after mount). Default values are removed from the URL to keep shared links clean; invalid param values are rejected and dropped.

Wired into:
- **Global filters**: `?period=` and `?tokens=` — shared links override the visitor's saved localStorage prefs
- **Transactions** (`/transactions`): `?flow=&senders=&recipients=&amountFrom=&amountTo=&page=` — opt-in via `syncFiltersToUrl` prop so embedded tables (dashboard, profile) don't pollute the URL; the filter panel auto-opens when a shared link carries filters
- **Leaderboard**: `?chain=&sortBy=&page=`
- **Flows**: `?unit=&mode=`

### 👤 Profile validation & share
- SUI/ETH address format validation with inline error messages (shared regexes extracted to `src/utils/address-validation.ts`, reused by global search); invalid addresses never trigger queries — no more silent empty results
- Typed addresses sync into the URL (debounced), clearing removes them
- New **Share profile** button that copies the current link with "Link copied!" feedback

### 🐛 Hydration bugs fixed along the way
- Page params (`?page=`) were being wiped on load by "reset page on filter change" effects reacting to URL/localStorage hydration — fixed with StrictMode-safe previous-value comparison instead of one-shot flags
- Avoided an SSR hydration mismatch by hydrating URL state in mount effects rather than `useState` initializers

## Test plan (verified in browser with live DB data)
- [x] `/leaderboard?chain=eth&sortBy=count&period=Last Week&page=1` restores tab, sort, period and page 2 (ranks 26–36)
- [x] `/transactions?flow=inflow&amountFrom=10000&page=2` restores filters + correct data page (rows 97–144); pagination writes `page=` back; changing a filter resets page and cleans the URL
- [x] `/flows?unit=count&mode=net` restores toggles; toggling back to defaults cleans the URL
- [x] Profile: share button copies exact URL; invalid input shows red error and blocks queries; valid input syncs URL
- [x] No hydration errors in console on any page; `yarn ts` passes